### PR TITLE
feat(searchbloc): add sample dataset and GCP demo with products index

### DIFF
--- a/blocs/searchbloc/main.tf
+++ b/blocs/searchbloc/main.tf
@@ -356,7 +356,6 @@ resource "kubernetes_deployment" "meili" {
     ignore_changes = [
       metadata[0].annotations["autopilot.gke.io/resource-adjustment"],
       metadata[0].annotations["autopilot.gke.io/warden-version"],
-      spec[0].template[0].metadata[0].annotations,
 
       # pod-level
       spec[0].template[0].spec[0].toleration,

--- a/blocs/searchbloc/ui/index.html
+++ b/blocs/searchbloc/ui/index.html
@@ -144,7 +144,7 @@
 
     <section class="card" role="search" aria-label="SearchBloc">
       <div class="searchbar">
-        <input id="index" class="input" placeholder="Index name (e.g. logs)" autocomplete="off"/>
+        <input id="index" class="input" placeholder="Index name (e.g. products)" autocomplete="off"/>
         <input id="q" class="input" placeholder="Type to search…" autocomplete="off"/>
         <button id="go" class="btn" aria-label="Run search">Search</button>
       </div>

--- a/examples/gcp/cb-searchbloc/README.md
+++ b/examples/gcp/cb-searchbloc/README.md
@@ -1,0 +1,297 @@
+# cb-searchbloc — SearchBloc (Meilisearch) Demo
+
+A minimal, production‑lean demo of **SearchBloc** powered by **Meilisearch** on GKE. This README walks you from zero → searchable UI using a realistic `products` index.
+
+> **Default public endpoint in examples:** `https://searchbloc.cloudbloc.io/api`
+> (Your Ingress/Nginx proxy maps `/api/*` → Meilisearch on `127.0.0.1:7700`.)
+
+---
+
+## What you get
+
+* **Meilisearch** deployed in Kubernetes (PVC-backed).
+* **Nginx reverse proxy**: `/` serves static UI, `/api/*` proxies to Meili.
+* **Public search-only API key** for browser demos.
+* A ready-to-query **`products`** index with sensible settings & sample data hooks.
+
+---
+
+## Prerequisites
+
+* GKE cluster reachable by `kubectl`/Terraform (or your Kubernetes cluster of choice).
+* Terraform installed (>= 1.5 recommended).
+* `curl`, `jq` for quick tests.
+* A Meili **master key** you will use for provisioning (never expose to browsers).
+
+> If you deployed via the Terraform module, you likely supplied `var.master_key` already. Use that same value here.
+
+---
+
+## Quick Start (10–15 min)
+
+### 0) Environment
+
+Export the master key you used to deploy Meilisearch (or plan to use):
+
+```bash
+export searchbloc_master_key="<your_meili_master_key>"
+export MEILI_ENDPOINT="https://searchbloc.cloudbloc.io/api"
+```
+
+> If your endpoint differs (e.g., internal port-forward):
+>
+> ```bash
+> export MEILI_ENDPOINT="http://127.0.0.1:7700"
+> ```
+
+### 1) Deploy / Update SearchBloc (Terraform)
+
+If you haven’t deployed the bloc yet, or you’ve just pulled fresh code:
+
+```bash
+# Optional: pass the master key to Terraform if your module expects it
+export TF_VAR_master_key="$searchbloc_master_key"
+
+terraform init
+terraform apply
+```
+
+This creates/updates the namespace, PVC, Meili Deployment/Service, Nginx proxy, Ingress, and (optionally) Managed Certificate + Cloud Armor if configured.
+
+### 2) Create a **public, search-only** API key (for the browser)
+
+> **Never** ship your master key to the browser. Create a scoped, expiring key.
+
+**macOS (BSD date):**
+
+```bash
+curl --fail-with-body -S -s -X POST "$MEILI_ENDPOINT/keys" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  -d "{\
+    \"name\": \"PublicSearch\",\
+    \"description\": \"Browser search-only key\",\
+    \"actions\": [\"search\"],\
+    \"indexes\": [\"products\"],\
+    \"expiresAt\": \"$(date -u -v+30d +%Y-%m-%dT%H:%M:%SZ)\"\
+  }"
+```
+
+**Linux (GNU date):**
+
+```bash
+curl --fail-with-body -S -s -X POST "$MEILI_ENDPOINT/keys" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  -d "{\
+    \"name\": \"PublicSearch\",\
+    \"description\": \"Browser search-only key\",\
+    \"actions\": [\"search\"],\
+    \"indexes\": [\"products\"],\
+    \"expiresAt\": \"$(date -u -d '+30 days' +%Y-%m-%dT%H:%M:%SZ)\"\
+  }"
+```
+
+> 🔐 **Least privilege**: prefer `\"indexes\": [\"products\"]` over `*` in production demos.
+
+The response contains `key` — copy it and export for Terraform wiring (if your UI consumes it via TF):
+
+```bash
+export TF_VAR_public_search_key="<the_key_value_from_response>"
+terraform apply
+```
+
+### 3) Create the `products` index
+
+```bash
+curl -S -s -X POST "$MEILI_ENDPOINT/indexes" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  --data '{"uid":"products","primaryKey":"id"}' | jq .
+```
+
+### 4) Tune index settings (searchable/filterable/sortable/displayed)
+
+```bash
+curl -S -s -X PATCH "$MEILI_ENDPOINT/indexes/products/settings" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "searchableAttributes": ["name","brand","description","tags","categories"],
+    "filterableAttributes":  ["brand","categories","colors","sizes","in_stock","price","rating","created_at"],
+    "sortableAttributes":    ["price","rating","reviews","created_at","name"],
+    "displayedAttributes":   ["id","name","brand","categories","price","rating","reviews","colors","in_stock","image_url","thumb_url","description"],
+    "faceting": { "maxValuesPerFacet": 30 }
+  }' | jq .
+```
+
+### 5) Seed documents
+
+Place a seed file at repo root (or provide a path) then import. The file can be a JSON **array** of objects.
+
+```bash
+# Example import (array JSON)
+curl -S -s -X POST "$MEILI_ENDPOINT/indexes/products/documents?primaryKey=id" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  --data-binary @products_seed_500.json | jq .
+```
+
+> **Tip:** You can also send NDJSON (`--data-binary @file.ndjson`).
+
+### 6) Verify search
+
+```bash
+# List indexes
+curl -s -H "Authorization: Bearer $searchbloc_master_key" "$MEILI_ENDPOINT/indexes" | jq .
+
+# Simple query
+curl -s -X POST "$MELI_ENDPOINT/indexes/products/search" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  --data '{"q":"shoes"}' | jq '.hits[0:3]'
+
+# Faceted + sorted
+curl -s -X POST "$MEILI_ENDPOINT/indexes/products/search" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "q": "running",
+    "filter": ["brand = Nike", "in_stock = true", "price < 200"],
+    "sort":   ["price:asc"],
+    "facets": ["brand","categories","colors","sizes"]
+  }' | jq '.hits[0:3]'
+```
+
+### 7) Open the demo UI
+
+Open your public URL (root path). The UI should be configured to call:
+
+```
+GET/POST  $MEILI_ENDPOINT/indexes/products/search
+Auth:     Bearer <PublicSearch key>
+```
+
+If your UI reads `TF_VAR_public_search_key`, re‑`terraform apply` after updating it.
+
+---
+
+## Module / Variables (common)
+
+Depending on your module version, the following variables are typical:
+
+* `namespace` — Kubernetes namespace for SearchBloc (e.g., `searchbloc` or `obsbloc`).
+* `app_name` — App label/name (e.g., `searchbloc`).
+* `master_key` — Meili master key (string). **Required.**
+* `public_search_key` — Optional; propagated to UI config/ConfigMap.
+* `storage_size` — PVC size (e.g., `5Gi`).
+* `storage_class_name` — Optional StorageClass name.
+* `cloudarmor_policy` — Optional. Attach a Cloud Armor policy to Ingress.
+* `edge_ip_name`, `managed_certificate` — Optional ingress/cert wiring.
+
+> Check your module’s `variables.tf` for the authoritative list.
+
+---
+
+## Security Notes
+
+* **Never** expose the master key to browsers or untrusted CI logs.
+* Prefer **index‑scoped** public keys (`indexes: ["products"]`) with **short expirations** (e.g., 30 days) and rotate.
+* If using a shared LB (e.g., with ObsBloc), ensure **HTTPS redirect** and **Cloud Armor** are applied at the Ingress.
+
+---
+
+## Troubleshooting
+
+* **403 Forbidden** when creating keys: wrong/missing `Authorization` header or incorrect master key.
+* **Index not found**: create it (`/indexes` POST) before updating settings or seeding.
+* **CORS issues in browser**: ensure your Nginx or Ingress adds proper CORS headers (or proxy from same origin).
+* **502/504 via Ingress**: check Service/Pod status; confirm Nginx proxy target is `127.0.0.1:7700`.
+* **413 Payload Too Large** when importing: split seed file, or increase proxy/body size limits in Nginx/Ingress.
+
+---
+
+## Maintenance / Ops
+
+* **Backups**: snapshot PVC or export documents via `/indexes/<uid>/documents`.
+* **Scaling**: add CPU/memory or tune Meili indexer options. Enable HPA on Nginx/Meili if desired.
+* **Logs**: forward Nginx/Meili logs to your Observability stack (ObsBloc) or Cloud Logging.
+
+---
+
+## API Cheat Sheet (copy‑paste friendly)
+
+```bash
+# Set endpoint/master key
+export MEILI_ENDPOINT="https://searchbloc.cloudbloc.io/api"
+export searchbloc_master_key="<master>"
+
+# Create a search-only key (macOS; limit to products)
+curl -S -s -X POST "$MEILI_ENDPOINT/keys" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  -d "{\
+    \"name\": \"PublicSearch\",\
+    \"description\": \"Browser search-only key\",\
+    \"actions\": [\"search\"],\
+    \"indexes\": [\"products\"],\
+    \"expiresAt\": \"$(date -u -v+30d +%Y-%m-%dT%H:%M:%SZ)\"\
+  }"
+
+# Export for Terraform/UI and apply
+export TF_VAR_public_search_key="<key_from_above>"
+terraform apply
+
+# Create index
+curl -S -s -X POST "$MEILI_ENDPOINT/indexes" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  --data '{"uid":"products","primaryKey":"id"}'
+
+# Configure settings
+curl -S -s -X PATCH "$MEILI_ENDPOINT/indexes/products/settings" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "searchableAttributes": ["name","brand","description","tags","categories"],
+    "filterableAttributes":  ["brand","categories","colors","sizes","in_stock","price","rating","created_at"],
+    "sortableAttributes":    ["price","rating","reviews","created_at","name"],
+    "displayedAttributes":   ["id","name","brand","categories","price","rating","reviews","colors","in_stock","image_url","thumb_url","description"],
+    "faceting": { "maxValuesPerFacet": 30 }
+  }'
+
+# Seed documents (array JSON)
+curl -S -s -X POST "$MEILI_ENDPOINT/indexes/products/documents?primaryKey=id" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  --data-binary @products_seed_500.json
+
+# Verify search
+curl -s -X POST "$MEILI_ENDPOINT/indexes/products/search" \
+  -H "Authorization: Bearer $searchbloc_master_key" \
+  -H "Content-Type: application/json" \
+  --data '{"q":"shoes"}' | jq '.hits[0:5]'
+```
+
+---
+
+## Cleanup
+
+```bash
+# Delete the search-only key
+# 1) List keys to find the key ID
+echo "List keys:" && curl -s -H "Authorization: Bearer $searchbloc_master_key" "$MEILI_ENDPOINT/keys" | jq '.[].uid? // .results[]?.uid? // .'
+# 2) Delete by key UID (replace <uid>)
+curl -X DELETE "$MEILI_ENDPOINT/keys/<uid>" -H "Authorization: Bearer $searchbloc_master_key"
+
+# Drop the index
+curl -X DELETE "$MEILI_ENDPOINT/indexes/products" -H "Authorization: Bearer $searchbloc_master_key"
+```
+
+---
+
+## Notes
+
+* If SearchBloc shares an HTTPS LB with ObsBloc, you don’t need a separate LB; just ensure the **FrontendConfig** forces HTTPS redirect and **Cloud Armor** is attached at the Ingress.
+* Use **restricted** public keys in demos; rotate monthly or per event.
+* For another vertical (docs/movies), replace the `uid` and attribute lists accordingly.

--- a/examples/gcp/cb-searchbloc/assets/products_seed_500_clean.json
+++ b/examples/gcp/cb-searchbloc/assets/products_seed_500_clean.json
@@ -1,0 +1,15202 @@
+[
+  {
+    "id": "sku_1000",
+    "name": "Urban Street 115 · 한정판",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 85.35,
+    "rating": 3.7,
+    "reviews": 1516,
+    "colors": [
+      "Blue",
+      "네이비",
+      "블랙"
+    ],
+    "sizes": [
+      "6",
+      "12",
+      "11",
+      "7",
+      "10",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "durable",
+      "eco",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-0-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-0-cloudbloc/240/180",
+    "created_at": "2025-08-08",
+    "description": "The Urban Street 115 · 한정판 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1001",
+    "name": "Cumulus Commuter 175",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 82.51,
+    "rating": 3.8,
+    "reviews": 1563,
+    "colors": [
+      "White",
+      "Purple",
+      "Forest"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "best-seller",
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-1-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-1-cloudbloc/240/180",
+    "created_at": "2025-03-05",
+    "description": "Lightweight yet durable, the Cumulus Commuter 175 by Cloudbloc delivers outstanding quality for bags enthusiasts."
+  },
+  {
+    "id": "sku_1002",
+    "name": "Echo Kettle 283",
+    "brand": "Northpeak",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 50.75,
+    "rating": 4.4,
+    "reviews": 1813,
+    "colors": [
+      "Blue",
+      "Navy",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "durable",
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-2-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-2-northpeak/240/180",
+    "created_at": "2025-01-04",
+    "description": "Echo Kettle 283 from Northpeak is a versatile home built for everyday use."
+  },
+  {
+    "id": "sku_1003",
+    "name": "Urban Daily 326",
+    "brand": "TrailForge",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 161.75,
+    "rating": 3.7,
+    "reviews": 727,
+    "colors": [
+      "Pink",
+      "Olive"
+    ],
+    "sizes": [
+      "10",
+      "11",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-3-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-3-trailforge/240/180",
+    "created_at": "2025-01-13",
+    "description": "Designed for comfort and durability, the Urban Daily 326 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1004",
+    "name": "Trail Carry 432",
+    "brand": "Seoulistic",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 148.72,
+    "rating": 3.6,
+    "reviews": 1683,
+    "colors": [
+      "Volt"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "durable",
+      "2025",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-4-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-4-seoulistic/240/180",
+    "created_at": "2024-12-27",
+    "description": "Trail Carry 432 from Seoulistic is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1005",
+    "name": "Stratus Headphones 72",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 120.25,
+    "rating": 4.3,
+    "reviews": 538,
+    "colors": [
+      "Blue",
+      "Forest",
+      "Volt",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight",
+      "best-seller",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-5-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-5-urbanmesh/240/180",
+    "created_at": "2024-11-19",
+    "description": "Stratus Headphones 72 from UrbanMesh is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1006",
+    "name": "Pulse Tee 198",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 41.66,
+    "rating": 5.0,
+    "reviews": 1083,
+    "colors": [
+      "Red",
+      "Black",
+      "White"
+    ],
+    "sizes": [
+      "XXL",
+      "M",
+      "XS",
+      "S",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "2025",
+      "durable",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-6-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-6-zenwave/240/180",
+    "created_at": "2024-09-11",
+    "description": "Designed for comfort and durability, the Pulse Tee 198 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1007",
+    "name": "Summit Street 79",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 111.13,
+    "rating": 3.7,
+    "reviews": 1952,
+    "colors": [
+      "Blue"
+    ],
+    "sizes": [
+      "9",
+      "6",
+      "11",
+      "8",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "lightweight",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-7-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-7-nimbusworks/240/180",
+    "created_at": "2025-01-11",
+    "description": "NimbusWorks's Summit Street 79 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1008",
+    "name": "Stratus Street 338",
+    "brand": "Seoulistic",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 122.28,
+    "rating": 4.3,
+    "reviews": 542,
+    "colors": [
+      "Navy",
+      "Red",
+      "Purple",
+      "Olive"
+    ],
+    "sizes": [
+      "11",
+      "12",
+      "8",
+      "9",
+      "10",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-8-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-8-seoulistic/240/180",
+    "created_at": "2025-01-03",
+    "description": "The Stratus Street 338 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1009",
+    "name": "Trail Stove 4",
+    "brand": "Seoulistic",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 46.91,
+    "rating": 4.4,
+    "reviews": 468,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "water-resistant",
+      "limited",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-9-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-9-seoulistic/240/180",
+    "created_at": "2024-10-16",
+    "description": "The Trail Stove 4 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1010",
+    "name": "Stratus Anorak 296",
+    "brand": "Seoulistic",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 154.53,
+    "rating": 4.7,
+    "reviews": 1653,
+    "colors": [
+      "Navy",
+      "White",
+      "Pink",
+      "Forest"
+    ],
+    "sizes": [
+      "XL",
+      "M",
+      "L",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-10-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-10-seoulistic/240/180",
+    "created_at": "2025-08-06",
+    "description": "Stratus Anorak 296 from Seoulistic is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1011",
+    "name": "Trail Bottle 98",
+    "brand": "Northpeak",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 29.7,
+    "rating": 3.7,
+    "reviews": 375,
+    "colors": [
+      "Tan",
+      "Navy",
+      "White"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-11-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-11-northpeak/240/180",
+    "created_at": "2025-06-18",
+    "description": "Northpeak's Trail Bottle 98 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1012",
+    "name": "Volt Pan 86",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 66.49,
+    "rating": 4.2,
+    "reviews": 1770,
+    "colors": [
+      "Black",
+      "Gray",
+      "Forest",
+      "Purple"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-12-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-12-cloudbloc/240/180",
+    "created_at": "2025-01-23",
+    "description": "Volt Pan 86 from Cloudbloc is a versatile home built for everyday use."
+  },
+  {
+    "id": "sku_1013",
+    "name": "Stratus Pan 152",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 40.26,
+    "rating": 3.6,
+    "reviews": 1506,
+    "colors": [
+      "Purple"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "new",
+      "best-seller",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-13-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-13-urbanmesh/240/180",
+    "created_at": "2024-10-05",
+    "description": "Stratus Pan 152 from UrbanMesh is a versatile home built for everyday use."
+  },
+  {
+    "id": "sku_1014",
+    "name": "Volt Fly 36",
+    "brand": "Seoulistic",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 167.35,
+    "rating": 4.5,
+    "reviews": 481,
+    "colors": [
+      "White",
+      "Blue",
+      "Navy",
+      "Black"
+    ],
+    "sizes": [
+      "6",
+      "9",
+      "10",
+      "8",
+      "7",
+      "12",
+      "11"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-14-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-14-seoulistic/240/180",
+    "created_at": "2025-03-31",
+    "description": "The Volt Fly 36 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1015",
+    "name": "Aurora Flask 319",
+    "brand": "Northpeak",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 44.95,
+    "rating": 5.0,
+    "reviews": 150,
+    "colors": [
+      "Red",
+      "Olive"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-15-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-15-northpeak/240/180",
+    "created_at": "2024-10-15",
+    "description": "Designed for comfort and durability, the Aurora Flask 319 is perfect for accessories needs."
+  },
+  {
+    "id": "sku_1016",
+    "name": "Wave Crew 314",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 79.0,
+    "rating": 4.7,
+    "reviews": 1083,
+    "colors": [
+      "Pink"
+    ],
+    "sizes": [
+      "XXL",
+      "XS",
+      "S",
+      "L",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-16-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-16-urbanmesh/240/180",
+    "created_at": "2025-06-20",
+    "description": "Wave Crew 314 from UrbanMesh is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1017",
+    "name": "Neo Stove 352",
+    "brand": "Voltline",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 260.38,
+    "rating": 3.9,
+    "reviews": 1000,
+    "colors": [
+      "Black",
+      "White",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-17-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-17-voltline/240/180",
+    "created_at": "2024-10-02",
+    "description": "The Neo Stove 352 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1018",
+    "name": "Cumulus Performance Tee 283",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 61.75,
+    "rating": 4.3,
+    "reviews": 229,
+    "colors": [
+      "Purple"
+    ],
+    "sizes": [
+      "XL",
+      "XS",
+      "M",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-18-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-18-nimbusworks/240/180",
+    "created_at": "2025-04-18",
+    "description": "NimbusWorks's Cumulus Performance Tee 283 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1019",
+    "name": "Flux Bottle 350",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 20.23,
+    "rating": 3.7,
+    "reviews": 1597,
+    "colors": [
+      "Blue",
+      "Gray",
+      "Navy",
+      "Pink"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-19-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-19-cloudbloc/240/180",
+    "created_at": "2024-09-22",
+    "description": "Cloudbloc's Flux Bottle 350 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1020",
+    "name": "Urban Earbuds 404",
+    "brand": "Voltline",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 288.47,
+    "rating": 4.1,
+    "reviews": 79,
+    "colors": [
+      "Navy",
+      "Purple",
+      "Tan",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-20-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-20-voltline/240/180",
+    "created_at": "2025-01-04",
+    "description": "Urban Earbuds 404 from Voltline is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1021",
+    "name": "Neo Puffer 443",
+    "brand": "TrailForge",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 73.88,
+    "rating": 4.7,
+    "reviews": 719,
+    "colors": [
+      "Pink",
+      "Red",
+      "Volt",
+      "Black"
+    ],
+    "sizes": [
+      "L",
+      "S",
+      "M"
+    ],
+    "in_stock": false,
+    "tags": [
+      "limited",
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-21-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-21-trailforge/240/180",
+    "created_at": "2025-07-12",
+    "description": "Neo Puffer 443 from TrailForge is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1022",
+    "name": "Summit Earbuds 198",
+    "brand": "PolarGrid",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 361.82,
+    "rating": 3.8,
+    "reviews": 90,
+    "colors": [
+      "Black",
+      "Red",
+      "Pink",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "new",
+      "water-resistant",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-22-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-22-polargrid/240/180",
+    "created_at": "2024-10-15",
+    "description": "Summit Earbuds 198 from PolarGrid is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1023",
+    "name": "Polar Commuter 168",
+    "brand": "Seoulistic",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 99.32,
+    "rating": 3.9,
+    "reviews": 260,
+    "colors": [
+      "Forest",
+      "Pink"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco",
+      "2025",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-23-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-23-seoulistic/240/180",
+    "created_at": "2024-12-08",
+    "description": "Seoulistic's Polar Commuter 168 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1024",
+    "name": "Zen Commuter 403",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 123.3,
+    "rating": 4.5,
+    "reviews": 952,
+    "colors": [
+      "Tan",
+      "Pink",
+      "Navy",
+      "Red"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "water-resistant",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-24-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-24-nimbusworks/240/180",
+    "created_at": "2024-12-05",
+    "description": "Lightweight yet durable, the Zen Commuter 403 by NimbusWorks delivers outstanding quality for bags enthusiasts."
+  },
+  {
+    "id": "sku_1025",
+    "name": "Trail Flask 116",
+    "brand": "Northpeak",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 38.62,
+    "rating": 3.7,
+    "reviews": 94,
+    "colors": [
+      "Tan",
+      "Blue"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "limited",
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-25-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-25-northpeak/240/180",
+    "created_at": "2025-07-29",
+    "description": "Designed for comfort and durability, the Trail Flask 116 is perfect for accessories needs."
+  },
+  {
+    "id": "sku_1026",
+    "name": "Trail Watch 336",
+    "brand": "TrailForge",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 367.8,
+    "rating": 4.8,
+    "reviews": 1762,
+    "colors": [
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight",
+      "new",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-26-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-26-trailforge/240/180",
+    "created_at": "2025-09-01",
+    "description": "The Trail Watch 336 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1027",
+    "name": "Stratus Daily 342",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 128.42,
+    "rating": 4.3,
+    "reviews": 649,
+    "colors": [
+      "Blue",
+      "Red",
+      "Forest",
+      "Pink"
+    ],
+    "sizes": [
+      "7",
+      "11",
+      "9",
+      "10",
+      "12",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "limited",
+      "durable",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-27-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-27-urbanmesh/240/180",
+    "created_at": "2025-01-29",
+    "description": "UrbanMesh's Stratus Daily 342 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1028",
+    "name": "Polar Watch 140",
+    "brand": "Northpeak",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 220.06,
+    "rating": 4.8,
+    "reviews": 165,
+    "colors": [
+      "Gray",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "lightweight",
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-28-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-28-northpeak/240/180",
+    "created_at": "2024-11-27",
+    "description": "Lightweight yet durable, the Polar Watch 140 by Northpeak delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1029",
+    "name": "Glide Flask 32",
+    "brand": "Seoulistic",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 18.83,
+    "rating": 4.1,
+    "reviews": 1853,
+    "colors": [
+      "Blue"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "2025",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-29-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-29-seoulistic/240/180",
+    "created_at": "2025-03-09",
+    "description": "The Glide Flask 32 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1030",
+    "name": "Tempo Pan 250",
+    "brand": "Seoulistic",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 40.5,
+    "rating": 4.2,
+    "reviews": 59,
+    "colors": [
+      "Volt",
+      "Pink",
+      "Forest",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "eco",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-30-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-30-seoulistic/240/180",
+    "created_at": "2024-11-14",
+    "description": "Lightweight yet durable, the Tempo Pan 250 by Seoulistic delivers outstanding quality for home enthusiasts."
+  },
+  {
+    "id": "sku_1031",
+    "name": "Pulse Fly 444",
+    "brand": "Northpeak",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 150.02,
+    "rating": 3.6,
+    "reviews": 776,
+    "colors": [
+      "Navy",
+      "Tan",
+      "Volt"
+    ],
+    "sizes": [
+      "12",
+      "9",
+      "8",
+      "11",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-31-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-31-northpeak/240/180",
+    "created_at": "2025-05-08",
+    "description": "Northpeak's Pulse Fly 444 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1032",
+    "name": "Nimbus Hoodie 487",
+    "brand": "Northpeak",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 109.46,
+    "rating": 4.8,
+    "reviews": 1272,
+    "colors": [
+      "Navy",
+      "Gray"
+    ],
+    "sizes": [
+      "S",
+      "L",
+      "XL",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-32-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-32-northpeak/240/180",
+    "created_at": "2025-03-17",
+    "description": "Lightweight yet durable, the Nimbus Hoodie 487 by Northpeak delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1033",
+    "name": "Ion Tee 476",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 37.34,
+    "rating": 4.5,
+    "reviews": 1962,
+    "colors": [
+      "Forest",
+      "Navy",
+      "White",
+      "Pink"
+    ],
+    "sizes": [
+      "XXL",
+      "M",
+      "XS"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-33-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-33-nimbusworks/240/180",
+    "created_at": "2025-06-26",
+    "description": "NimbusWorks's Ion Tee 476 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1034",
+    "name": "Volt Speaker 332",
+    "brand": "AuroraLab",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 155.26,
+    "rating": 4.8,
+    "reviews": 1684,
+    "colors": [
+      "White",
+      "Forest",
+      "Volt",
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-34-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-34-auroralab/240/180",
+    "created_at": "2025-04-20",
+    "description": "Lightweight yet durable, the Volt Speaker 332 by AuroraLab delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1035",
+    "name": "Glide Knife Set 423",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 111.61,
+    "rating": 3.9,
+    "reviews": 1744,
+    "colors": [
+      "White",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "water-resistant",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-35-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-35-urbanmesh/240/180",
+    "created_at": "2025-01-12",
+    "description": "UrbanMesh's Glide Knife Set 423 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1036",
+    "name": "Cumulus Band 109",
+    "brand": "AuroraLab",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 228.03,
+    "rating": 3.9,
+    "reviews": 572,
+    "colors": [
+      "Red",
+      "Black",
+      "Purple"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-36-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-36-auroralab/240/180",
+    "created_at": "2024-10-23",
+    "description": "Designed for comfort and durability, the Cumulus Band 109 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1037",
+    "name": "Atlas Knife Set 230",
+    "brand": "Voltline",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 120.22,
+    "rating": 3.6,
+    "reviews": 453,
+    "colors": [
+      "Purple",
+      "Navy",
+      "Olive",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-37-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-37-voltline/240/180",
+    "created_at": "2025-06-08",
+    "description": "Voltline's Atlas Knife Set 230 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1038",
+    "name": "Glide Flask 157",
+    "brand": "AuroraLab",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 20.3,
+    "rating": 3.7,
+    "reviews": 394,
+    "colors": [
+      "White",
+      "Red",
+      "Gray"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-38-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-38-auroralab/240/180",
+    "created_at": "2025-05-15",
+    "description": "The Glide Flask 157 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1039",
+    "name": "Flux Pack 155",
+    "brand": "Voltline",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 46.91,
+    "rating": 4.3,
+    "reviews": 561,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight",
+      "best-seller",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-39-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-39-voltline/240/180",
+    "created_at": "2024-11-13",
+    "description": "Flux Pack 155 from Voltline is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1040",
+    "name": "Atlas Commuter 175",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 69.89,
+    "rating": 3.6,
+    "reviews": 1927,
+    "colors": [
+      "White",
+      "Purple",
+      "Forest",
+      "Tan"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-40-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-40-urbanmesh/240/180",
+    "created_at": "2025-08-27",
+    "description": "Designed for comfort and durability, the Atlas Commuter 175 is perfect for bags needs."
+  },
+  {
+    "id": "sku_1041",
+    "name": "Volt Stove 61",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 231.51,
+    "rating": 4.1,
+    "reviews": 1220,
+    "colors": [
+      "Red",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "water-resistant",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-41-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-41-nimbusworks/240/180",
+    "created_at": "2025-04-24",
+    "description": "Volt Stove 61 from NimbusWorks is a versatile outdoors built for everyday use."
+  },
+  {
+    "id": "sku_1042",
+    "name": "Tempo Tent 486",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 309.08,
+    "rating": 4.4,
+    "reviews": 541,
+    "colors": [
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-42-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-42-cloudbloc/240/180",
+    "created_at": "2025-06-19",
+    "description": "The Tempo Tent 486 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1043",
+    "name": "Tempo Headphones 150",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 41.08,
+    "rating": 3.9,
+    "reviews": 579,
+    "colors": [
+      "White",
+      "Pink",
+      "Navy",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "2025",
+      "lightweight",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-43-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-43-urbanmesh/240/180",
+    "created_at": "2025-07-27",
+    "description": "Tempo Headphones 150 from UrbanMesh is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1044",
+    "name": "Urban Shell 37",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 71.93,
+    "rating": 4.7,
+    "reviews": 1218,
+    "colors": [
+      "Tan",
+      "White",
+      "Purple"
+    ],
+    "sizes": [
+      "XL",
+      "M",
+      "L",
+      "S"
+    ],
+    "in_stock": false,
+    "tags": [
+      "limited",
+      "new",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-44-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-44-zenwave/240/180",
+    "created_at": "2024-09-30",
+    "description": "Urban Shell 37 from Zenwave is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1045",
+    "name": "Trail Racer 301",
+    "brand": "Northpeak",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 213.6,
+    "rating": 5.0,
+    "reviews": 1376,
+    "colors": [
+      "Blue",
+      "Black",
+      "Gray"
+    ],
+    "sizes": [
+      "10",
+      "11",
+      "9",
+      "8",
+      "6",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-45-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-45-northpeak/240/180",
+    "created_at": "2025-05-19",
+    "description": "The Trail Racer 301 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1046",
+    "name": "Neo Speaker 54",
+    "brand": "AuroraLab",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 346.36,
+    "rating": 4.0,
+    "reviews": 1420,
+    "colors": [
+      "Olive",
+      "Pink",
+      "Forest",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "new",
+      "water-resistant",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-46-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-46-auroralab/240/180",
+    "created_at": "2024-10-25",
+    "description": "AuroraLab's Neo Speaker 54 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1047",
+    "name": "Aurora Speaker 446",
+    "brand": "Seoulistic",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 229.76,
+    "rating": 4.1,
+    "reviews": 384,
+    "colors": [
+      "Blue",
+      "Tan",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "2025",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-47-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-47-seoulistic/240/180",
+    "created_at": "2024-12-23",
+    "description": "Designed for comfort and durability, the Aurora Speaker 446 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1048",
+    "name": "Aurora Tracker 312",
+    "brand": "Northpeak",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 414.71,
+    "rating": 4.6,
+    "reviews": 636,
+    "colors": [
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-48-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-48-northpeak/240/180",
+    "created_at": "2025-01-03",
+    "description": "Northpeak's Aurora Tracker 312 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1049",
+    "name": "Polar Crew 213",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 69.75,
+    "rating": 5.0,
+    "reviews": 499,
+    "colors": [
+      "Red",
+      "Gray",
+      "Forest",
+      "Navy"
+    ],
+    "sizes": [
+      "XS",
+      "M",
+      "L",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "water-resistant",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-49-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-49-urbanmesh/240/180",
+    "created_at": "2025-05-27",
+    "description": "Polar Crew 213 from UrbanMesh is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1050",
+    "name": "Aero Commuter 444 · 한정판",
+    "brand": "PolarGrid",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 65.06,
+    "rating": 4.3,
+    "reviews": 706,
+    "colors": [
+      "블랙",
+      "네이비",
+      "Red",
+      "Purple",
+      "Forest"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "new",
+      "2025",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-50-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-50-polargrid/240/180",
+    "created_at": "2024-12-15",
+    "description": "The Aero Commuter 444 · 한정판 combines modern style with reliable performance in bags gear."
+  },
+  {
+    "id": "sku_1051",
+    "name": "Neo Speaker 243",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 289.93,
+    "rating": 4.7,
+    "reviews": 790,
+    "colors": [
+      "Tan",
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "best-seller",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-51-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-51-cloudbloc/240/180",
+    "created_at": "2025-07-09",
+    "description": "Cloudbloc's Neo Speaker 243 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1052",
+    "name": "Glide Classic 370",
+    "brand": "Seoulistic",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 85.86,
+    "rating": 4.8,
+    "reviews": 1986,
+    "colors": [
+      "White",
+      "Tan"
+    ],
+    "sizes": [
+      "8",
+      "10",
+      "9",
+      "6",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-52-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-52-seoulistic/240/180",
+    "created_at": "2025-06-10",
+    "description": "Designed for comfort and durability, the Glide Classic 370 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1053",
+    "name": "Nimbus Tracker 36",
+    "brand": "Seoulistic",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 177.6,
+    "rating": 4.5,
+    "reviews": 588,
+    "colors": [
+      "Purple",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "eco",
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-53-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-53-seoulistic/240/180",
+    "created_at": "2024-10-30",
+    "description": "Designed for comfort and durability, the Nimbus Tracker 36 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1054",
+    "name": "Neo Runner 151",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 136.6,
+    "rating": 4.1,
+    "reviews": 500,
+    "colors": [
+      "Blue",
+      "Pink",
+      "Gray",
+      "Purple"
+    ],
+    "sizes": [
+      "6",
+      "10",
+      "9",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-54-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-54-cloudbloc/240/180",
+    "created_at": "2025-07-05",
+    "description": "Lightweight yet durable, the Neo Runner 151 by Cloudbloc delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1055",
+    "name": "Urban Daypack 461",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 153.63,
+    "rating": 4.9,
+    "reviews": 1387,
+    "colors": [
+      "White",
+      "Tan"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "limited",
+      "water-resistant",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-55-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-55-urbanmesh/240/180",
+    "created_at": "2025-02-10",
+    "description": "UrbanMesh's Urban Daypack 461 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1056",
+    "name": "Echo Commuter 55",
+    "brand": "Voltline",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 77.02,
+    "rating": 4.4,
+    "reviews": 1177,
+    "colors": [
+      "Purple",
+      "Olive",
+      "Black"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-56-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-56-voltline/240/180",
+    "created_at": "2025-06-26",
+    "description": "Echo Commuter 55 from Voltline is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1057",
+    "name": "Tempo Carry 113",
+    "brand": "Voltline",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 130.94,
+    "rating": 4.4,
+    "reviews": 1388,
+    "colors": [
+      "Pink",
+      "White"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-57-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-57-voltline/240/180",
+    "created_at": "2025-04-23",
+    "description": "The Tempo Carry 113 combines modern style with reliable performance in bags gear."
+  },
+  {
+    "id": "sku_1058",
+    "name": "Polar Crew 383",
+    "brand": "Northpeak",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 43.76,
+    "rating": 3.8,
+    "reviews": 1610,
+    "colors": [
+      "Red",
+      "Purple",
+      "Olive"
+    ],
+    "sizes": [
+      "M",
+      "L",
+      "XXL",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-58-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-58-northpeak/240/180",
+    "created_at": "2024-11-07",
+    "description": "Northpeak's Polar Crew 383 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1059",
+    "name": "Flux Earbuds 405",
+    "brand": "Seoulistic",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 174.99,
+    "rating": 3.9,
+    "reviews": 253,
+    "colors": [
+      "Volt",
+      "Pink",
+      "Olive",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-59-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-59-seoulistic/240/180",
+    "created_at": "2025-03-19",
+    "description": "Flux Earbuds 405 from Seoulistic is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1060",
+    "name": "Wave Stride 469",
+    "brand": "PolarGrid",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 169.31,
+    "rating": 4.5,
+    "reviews": 1301,
+    "colors": [
+      "Purple",
+      "Olive",
+      "Forest",
+      "White"
+    ],
+    "sizes": [
+      "6",
+      "12",
+      "8",
+      "9"
+    ],
+    "in_stock": false,
+    "tags": [
+      "water-resistant",
+      "eco",
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-60-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-60-polargrid/240/180",
+    "created_at": "2025-01-08",
+    "description": "PolarGrid's Wave Stride 469 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1061",
+    "name": "Aero Pan 454",
+    "brand": "TrailForge",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 67.67,
+    "rating": 3.6,
+    "reviews": 1002,
+    "colors": [
+      "Olive",
+      "Black",
+      "Volt",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "limited",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-61-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-61-trailforge/240/180",
+    "created_at": "2025-01-08",
+    "description": "The Aero Pan 454 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1062",
+    "name": "Nimbus Knife Set 142",
+    "brand": "AuroraLab",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 36.38,
+    "rating": 3.7,
+    "reviews": 1736,
+    "colors": [
+      "White",
+      "Pink",
+      "Navy",
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-62-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-62-auroralab/240/180",
+    "created_at": "2025-02-27",
+    "description": "Designed for comfort and durability, the Nimbus Knife Set 142 is perfect for home needs."
+  },
+  {
+    "id": "sku_1063",
+    "name": "Volt Stove 301",
+    "brand": "Voltline",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 101.85,
+    "rating": 4.8,
+    "reviews": 672,
+    "colors": [
+      "Blue",
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-63-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-63-voltline/240/180",
+    "created_at": "2024-11-23",
+    "description": "Voltline's Volt Stove 301 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1064",
+    "name": "Aurora Tech Tee 8",
+    "brand": "Northpeak",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 40.21,
+    "rating": 4.7,
+    "reviews": 1205,
+    "colors": [
+      "Black",
+      "Gray",
+      "Olive"
+    ],
+    "sizes": [
+      "S",
+      "L",
+      "XS"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "new",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-64-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-64-northpeak/240/180",
+    "created_at": "2025-05-11",
+    "description": "Northpeak's Aurora Tech Tee 8 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1065",
+    "name": "Summit Street 485",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 137.66,
+    "rating": 4.6,
+    "reviews": 1861,
+    "colors": [
+      "Tan",
+      "Pink",
+      "Black"
+    ],
+    "sizes": [
+      "9",
+      "12",
+      "11"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight",
+      "best-seller",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-65-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-65-urbanmesh/240/180",
+    "created_at": "2025-05-19",
+    "description": "Designed for comfort and durability, the Summit Street 485 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1066",
+    "name": "Volt Stove 141",
+    "brand": "Zenwave",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 256.62,
+    "rating": 4.4,
+    "reviews": 1458,
+    "colors": [
+      "Forest",
+      "Blue",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "lightweight",
+      "limited",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-66-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-66-zenwave/240/180",
+    "created_at": "2025-05-26",
+    "description": "Lightweight yet durable, the Volt Stove 141 by Zenwave delivers outstanding quality for outdoors enthusiasts."
+  },
+  {
+    "id": "sku_1067",
+    "name": "Pulse Knife Set 455",
+    "brand": "Voltline",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 41.76,
+    "rating": 4.0,
+    "reviews": 928,
+    "colors": [
+      "Forest",
+      "White",
+      "Volt",
+      "Purple"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-67-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-67-voltline/240/180",
+    "created_at": "2025-01-18",
+    "description": "Voltline's Pulse Knife Set 455 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1068",
+    "name": "Volt Classic 222",
+    "brand": "Northpeak",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 80.62,
+    "rating": 4.6,
+    "reviews": 1662,
+    "colors": [
+      "Red",
+      "Black"
+    ],
+    "sizes": [
+      "10",
+      "12",
+      "8",
+      "6",
+      "7",
+      "11",
+      "9"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "water-resistant",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-68-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-68-northpeak/240/180",
+    "created_at": "2024-10-06",
+    "description": "Northpeak's Volt Classic 222 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1069",
+    "name": "Zen Stove 337",
+    "brand": "Seoulistic",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 202.75,
+    "rating": 4.8,
+    "reviews": 717,
+    "colors": [
+      "White",
+      "Olive",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new",
+      "limited",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-69-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-69-seoulistic/240/180",
+    "created_at": "2025-04-17",
+    "description": "Zen Stove 337 from Seoulistic is a versatile outdoors built for everyday use."
+  },
+  {
+    "id": "sku_1070",
+    "name": "Urban Stride 472",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 134.18,
+    "rating": 3.5,
+    "reviews": 1781,
+    "colors": [
+      "Blue",
+      "Pink"
+    ],
+    "sizes": [
+      "6",
+      "7",
+      "12",
+      "10",
+      "8",
+      "9"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-70-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-70-zenwave/240/180",
+    "created_at": "2025-04-30",
+    "description": "Lightweight yet durable, the Urban Stride 472 by Zenwave delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1071",
+    "name": "Tempo Bottle 453",
+    "brand": "PolarGrid",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 13.74,
+    "rating": 3.7,
+    "reviews": 1265,
+    "colors": [
+      "Pink"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "new",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-71-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-71-polargrid/240/180",
+    "created_at": "2025-08-14",
+    "description": "Lightweight yet durable, the Tempo Bottle 453 by PolarGrid delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1072",
+    "name": "Zen Speaker 59",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 156.71,
+    "rating": 3.7,
+    "reviews": 1388,
+    "colors": [
+      "Red",
+      "Pink",
+      "Olive",
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-72-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-72-nimbusworks/240/180",
+    "created_at": "2025-07-13",
+    "description": "NimbusWorks's Zen Speaker 59 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1073",
+    "name": "Stratus Carry 149",
+    "brand": "Voltline",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 89.3,
+    "rating": 3.5,
+    "reviews": 1529,
+    "colors": [
+      "Gray",
+      "Purple",
+      "Forest",
+      "Red"
+    ],
+    "sizes": [
+      "20L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-73-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-73-voltline/240/180",
+    "created_at": "2025-08-18",
+    "description": "The Stratus Carry 149 combines modern style with reliable performance in bags gear."
+  },
+  {
+    "id": "sku_1074",
+    "name": "Aurora Sprint 472",
+    "brand": "TrailForge",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 100.12,
+    "rating": 4.0,
+    "reviews": 879,
+    "colors": [
+      "Purple",
+      "Pink",
+      "Forest",
+      "Olive"
+    ],
+    "sizes": [
+      "9",
+      "6",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-74-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-74-trailforge/240/180",
+    "created_at": "2025-07-23",
+    "description": "TrailForge's Aurora Sprint 472 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1075",
+    "name": "Pulse Daily 269",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 78.65,
+    "rating": 4.8,
+    "reviews": 1527,
+    "colors": [
+      "Navy",
+      "Volt",
+      "Gray"
+    ],
+    "sizes": [
+      "10",
+      "11",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-75-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-75-voltline/240/180",
+    "created_at": "2024-12-18",
+    "description": "Lightweight yet durable, the Pulse Daily 269 by Voltline delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1076",
+    "name": "Ion Tech Tee 132",
+    "brand": "Voltline",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 30.23,
+    "rating": 4.4,
+    "reviews": 1556,
+    "colors": [
+      "Gray"
+    ],
+    "sizes": [
+      "L",
+      "XL",
+      "XXL",
+      "M",
+      "S",
+      "XS"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "limited",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-76-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-76-voltline/240/180",
+    "created_at": "2024-10-14",
+    "description": "Lightweight yet durable, the Ion Tech Tee 132 by Voltline delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1077",
+    "name": "Nimbus Carry 260",
+    "brand": "PolarGrid",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 55.02,
+    "rating": 4.2,
+    "reviews": 77,
+    "colors": [
+      "Volt"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "best-seller",
+      "eco",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-77-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-77-polargrid/240/180",
+    "created_at": "2024-10-26",
+    "description": "Nimbus Carry 260 from PolarGrid is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1078",
+    "name": "Aero Fly 165",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 168.65,
+    "rating": 4.3,
+    "reviews": 1961,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [
+      "12",
+      "8",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-78-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-78-urbanmesh/240/180",
+    "created_at": "2024-12-07",
+    "description": "Designed for comfort and durability, the Aero Fly 165 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1079",
+    "name": "Summit Tracker 313",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 145.67,
+    "rating": 4.1,
+    "reviews": 579,
+    "colors": [
+      "Forest",
+      "Volt",
+      "Blue",
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "water-resistant",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-79-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-79-urbanmesh/240/180",
+    "created_at": "2025-08-07",
+    "description": "UrbanMesh's Summit Tracker 313 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1080",
+    "name": "Polar Mug 371",
+    "brand": "TrailForge",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 128.37,
+    "rating": 4.9,
+    "reviews": 1234,
+    "colors": [
+      "Volt",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "limited",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-80-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-80-trailforge/240/180",
+    "created_at": "2024-11-21",
+    "description": "Polar Mug 371 from TrailForge is a versatile home built for everyday use."
+  },
+  {
+    "id": "sku_1081",
+    "name": "Tempo Speaker 481",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 60.35,
+    "rating": 4.3,
+    "reviews": 1317,
+    "colors": [
+      "Gray",
+      "Pink",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "limited",
+      "lightweight",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-81-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-81-zenwave/240/180",
+    "created_at": "2025-08-19",
+    "description": "Zenwave's Tempo Speaker 481 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1082",
+    "name": "Zen Carry 486",
+    "brand": "Zenwave",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 148.43,
+    "rating": 3.8,
+    "reviews": 281,
+    "colors": [
+      "White",
+      "Olive"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "limited",
+      "water-resistant",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-82-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-82-zenwave/240/180",
+    "created_at": "2025-06-13",
+    "description": "The Zen Carry 486 combines modern style with reliable performance in bags gear."
+  },
+  {
+    "id": "sku_1083",
+    "name": "Echo Tech Tee 84",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 29.21,
+    "rating": 4.5,
+    "reviews": 1279,
+    "colors": [
+      "Purple",
+      "Tan"
+    ],
+    "sizes": [
+      "L",
+      "M",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-83-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-83-polargrid/240/180",
+    "created_at": "2025-07-19",
+    "description": "Echo Tech Tee 84 from PolarGrid is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1084",
+    "name": "Atlas Shell 189",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 195.66,
+    "rating": 4.4,
+    "reviews": 902,
+    "colors": [
+      "Olive",
+      "Forest",
+      "Red",
+      "Blue"
+    ],
+    "sizes": [
+      "M",
+      "S",
+      "L",
+      "XL"
+    ],
+    "in_stock": false,
+    "tags": [
+      "durable",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-84-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-84-nimbusworks/240/180",
+    "created_at": "2025-05-14",
+    "description": "NimbusWorks's Atlas Shell 189 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1085",
+    "name": "Volt Street 140",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 119.43,
+    "rating": 4.3,
+    "reviews": 1701,
+    "colors": [
+      "White",
+      "Navy",
+      "Tan",
+      "Volt"
+    ],
+    "sizes": [
+      "9",
+      "6",
+      "12"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "water-resistant",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-85-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-85-nimbusworks/240/180",
+    "created_at": "2025-01-08",
+    "description": "The Volt Street 140 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1086",
+    "name": "Ion Stride 406",
+    "brand": "AuroraLab",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 108.99,
+    "rating": 3.6,
+    "reviews": 1878,
+    "colors": [
+      "Purple",
+      "Gray",
+      "Tan",
+      "Blue"
+    ],
+    "sizes": [
+      "6",
+      "12",
+      "11",
+      "8",
+      "10",
+      "9",
+      "7"
+    ],
+    "in_stock": false,
+    "tags": [
+      "new",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-86-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-86-auroralab/240/180",
+    "created_at": "2025-02-04",
+    "description": "Designed for comfort and durability, the Ion Stride 406 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1087",
+    "name": "Pulse Racer 235",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 98.16,
+    "rating": 4.8,
+    "reviews": 1023,
+    "colors": [
+      "Pink"
+    ],
+    "sizes": [
+      "10",
+      "7",
+      "11",
+      "8",
+      "12",
+      "6",
+      "9"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-87-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-87-voltline/240/180",
+    "created_at": "2025-04-11",
+    "description": "Pulse Racer 235 from Voltline is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1088",
+    "name": "Summit Bottle 200",
+    "brand": "Northpeak",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 40.82,
+    "rating": 3.6,
+    "reviews": 792,
+    "colors": [
+      "Olive",
+      "Black",
+      "Volt"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "best-seller",
+      "new",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-88-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-88-northpeak/240/180",
+    "created_at": "2025-08-12",
+    "description": "The Summit Bottle 200 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1089",
+    "name": "Flux Crew 417",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 57.85,
+    "rating": 4.7,
+    "reviews": 1402,
+    "colors": [
+      "Purple",
+      "Tan",
+      "Gray",
+      "Blue"
+    ],
+    "sizes": [
+      "XXL",
+      "L",
+      "XS"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-89-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-89-cloudbloc/240/180",
+    "created_at": "2024-10-02",
+    "description": "Cloudbloc's Flux Crew 417 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1090",
+    "name": "Echo Commuter 130",
+    "brand": "Seoulistic",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 49.94,
+    "rating": 4.5,
+    "reviews": 585,
+    "colors": [
+      "Black",
+      "Pink",
+      "Volt"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-90-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-90-seoulistic/240/180",
+    "created_at": "2025-03-17",
+    "description": "Lightweight yet durable, the Echo Commuter 130 by Seoulistic delivers outstanding quality for bags enthusiasts."
+  },
+  {
+    "id": "sku_1091",
+    "name": "Cumulus Headphones 355",
+    "brand": "AuroraLab",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 213.08,
+    "rating": 4.9,
+    "reviews": 1063,
+    "colors": [
+      "White",
+      "Forest",
+      "Purple"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "water-resistant",
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-91-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-91-auroralab/240/180",
+    "created_at": "2024-12-11",
+    "description": "AuroraLab's Cumulus Headphones 355 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1092",
+    "name": "Polar Flask 309",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 35.68,
+    "rating": 3.7,
+    "reviews": 909,
+    "colors": [
+      "Tan",
+      "Black",
+      "Volt"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "2025",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-92-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-92-nimbusworks/240/180",
+    "created_at": "2025-01-28",
+    "description": "Designed for comfort and durability, the Polar Flask 309 is perfect for accessories needs."
+  },
+  {
+    "id": "sku_1093",
+    "name": "Cumulus Bottle 74",
+    "brand": "Seoulistic",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 40.01,
+    "rating": 4.5,
+    "reviews": 897,
+    "colors": [
+      "Gray"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "eco",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-93-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-93-seoulistic/240/180",
+    "created_at": "2025-08-06",
+    "description": "Seoulistic's Cumulus Bottle 74 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1094",
+    "name": "Stratus Sprint 486",
+    "brand": "PolarGrid",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 138.23,
+    "rating": 4.2,
+    "reviews": 157,
+    "colors": [
+      "Red",
+      "Volt"
+    ],
+    "sizes": [
+      "8",
+      "11",
+      "12",
+      "7",
+      "6",
+      "10"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "new",
+      "lightweight",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-94-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-94-polargrid/240/180",
+    "created_at": "2025-05-23",
+    "description": "The Stratus Sprint 486 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1095",
+    "name": "Zen Carry 356",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 168.72,
+    "rating": 4.2,
+    "reviews": 251,
+    "colors": [
+      "White",
+      "Tan"
+    ],
+    "sizes": [
+      "20L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-95-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-95-urbanmesh/240/180",
+    "created_at": "2025-04-25",
+    "description": "UrbanMesh's Zen Carry 356 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1096",
+    "name": "Wave Flask 457",
+    "brand": "Northpeak",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 21.9,
+    "rating": 3.7,
+    "reviews": 1453,
+    "colors": [
+      "Volt",
+      "Red"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-96-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-96-northpeak/240/180",
+    "created_at": "2024-12-21",
+    "description": "The Wave Flask 457 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1097",
+    "name": "Flux Tracker 294",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 233.94,
+    "rating": 4.7,
+    "reviews": 1129,
+    "colors": [
+      "Blue",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "2025",
+      "new",
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-97-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-97-cloudbloc/240/180",
+    "created_at": "2025-04-01",
+    "description": "Designed for comfort and durability, the Flux Tracker 294 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1098",
+    "name": "Stratus Lantern 329",
+    "brand": "Northpeak",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 48.11,
+    "rating": 4.2,
+    "reviews": 1059,
+    "colors": [
+      "Gray",
+      "Red",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-98-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-98-northpeak/240/180",
+    "created_at": "2024-11-15",
+    "description": "Designed for comfort and durability, the Stratus Lantern 329 is perfect for outdoors needs."
+  },
+  {
+    "id": "sku_1099",
+    "name": "Polar Pan 83",
+    "brand": "Zenwave",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 54.85,
+    "rating": 4.6,
+    "reviews": 708,
+    "colors": [
+      "White",
+      "Olive",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "limited",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-99-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-99-zenwave/240/180",
+    "created_at": "2025-06-19",
+    "description": "Zenwave's Polar Pan 83 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1100",
+    "name": "Volt Stove 304 · 한정판",
+    "brand": "Seoulistic",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 376.87,
+    "rating": 3.7,
+    "reviews": 1349,
+    "colors": [
+      "블랙",
+      "네이비",
+      "Pink",
+      "Black",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "new",
+      "limited",
+      "durable",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-100-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-100-seoulistic/240/180",
+    "created_at": "2025-08-04",
+    "description": "Seoulistic's Volt Stove 304 · 한정판 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1101",
+    "name": "Aurora Headphones 456",
+    "brand": "PolarGrid",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 261.05,
+    "rating": 3.9,
+    "reviews": 1959,
+    "colors": [
+      "Tan",
+      "Navy",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "durable",
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-101-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-101-polargrid/240/180",
+    "created_at": "2024-10-17",
+    "description": "Aurora Headphones 456 from PolarGrid is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1102",
+    "name": "Zen Band 311",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 139.34,
+    "rating": 4.8,
+    "reviews": 653,
+    "colors": [
+      "Forest",
+      "Gray",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "2025",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-102-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-102-urbanmesh/240/180",
+    "created_at": "2024-11-03",
+    "description": "Zen Band 311 from UrbanMesh is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1103",
+    "name": "Trail Pack 50",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 51.83,
+    "rating": 4.9,
+    "reviews": 1769,
+    "colors": [
+      "Navy",
+      "Gray",
+      "Volt",
+      "Blue"
+    ],
+    "sizes": [
+      "20L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "eco",
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-103-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-103-urbanmesh/240/180",
+    "created_at": "2025-05-23",
+    "description": "Trail Pack 50 from UrbanMesh is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1104",
+    "name": "Echo Racer 235",
+    "brand": "Northpeak",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 215.67,
+    "rating": 3.8,
+    "reviews": 722,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [
+      "9",
+      "10",
+      "12",
+      "8",
+      "11"
+    ],
+    "in_stock": false,
+    "tags": [
+      "water-resistant",
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-104-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-104-northpeak/240/180",
+    "created_at": "2024-11-04",
+    "description": "Echo Racer 235 from Northpeak is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1105",
+    "name": "Flux Bottle 206",
+    "brand": "TrailForge",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 13.69,
+    "rating": 4.3,
+    "reviews": 742,
+    "colors": [
+      "White",
+      "Forest",
+      "Red"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "2025",
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-105-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-105-trailforge/240/180",
+    "created_at": "2025-01-31",
+    "description": "Flux Bottle 206 from TrailForge is a versatile accessories built for everyday use."
+  },
+  {
+    "id": "sku_1106",
+    "name": "Wave Flask 387",
+    "brand": "AuroraLab",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 16.76,
+    "rating": 4.4,
+    "reviews": 822,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-106-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-106-auroralab/240/180",
+    "created_at": "2025-02-27",
+    "description": "Designed for comfort and durability, the Wave Flask 387 is perfect for accessories needs."
+  },
+  {
+    "id": "sku_1107",
+    "name": "Neo Mug 84",
+    "brand": "Zenwave",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 64.62,
+    "rating": 4.4,
+    "reviews": 1725,
+    "colors": [
+      "Blue",
+      "Volt",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-107-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-107-zenwave/240/180",
+    "created_at": "2025-06-09",
+    "description": "Lightweight yet durable, the Neo Mug 84 by Zenwave delivers outstanding quality for home enthusiasts."
+  },
+  {
+    "id": "sku_1108",
+    "name": "Ion Flask 299",
+    "brand": "AuroraLab",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 22.15,
+    "rating": 4.8,
+    "reviews": 1786,
+    "colors": [
+      "Blue"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "limited",
+      "lightweight",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-108-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-108-auroralab/240/180",
+    "created_at": "2025-08-11",
+    "description": "The Ion Flask 299 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1109",
+    "name": "Summit Tracker 370",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 339.29,
+    "rating": 4.8,
+    "reviews": 302,
+    "colors": [
+      "Black",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-109-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-109-zenwave/240/180",
+    "created_at": "2024-11-05",
+    "description": "Lightweight yet durable, the Summit Tracker 370 by Zenwave delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1110",
+    "name": "Stratus Flask 354",
+    "brand": "TrailForge",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 18.73,
+    "rating": 4.3,
+    "reviews": 1252,
+    "colors": [
+      "Purple",
+      "Black",
+      "Gray",
+      "Red"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "water-resistant",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-110-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-110-trailforge/240/180",
+    "created_at": "2025-08-15",
+    "description": "Stratus Flask 354 from TrailForge is a versatile accessories built for everyday use."
+  },
+  {
+    "id": "sku_1111",
+    "name": "Neo Tracker 182",
+    "brand": "Seoulistic",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 362.86,
+    "rating": 4.8,
+    "reviews": 1394,
+    "colors": [
+      "Blue",
+      "Tan",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "durable",
+      "water-resistant",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-111-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-111-seoulistic/240/180",
+    "created_at": "2025-01-30",
+    "description": "Neo Tracker 182 from Seoulistic is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1112",
+    "name": "Neo Jacket 179",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 172.1,
+    "rating": 4.9,
+    "reviews": 1477,
+    "colors": [
+      "Olive",
+      "White",
+      "Blue"
+    ],
+    "sizes": [
+      "XL",
+      "M",
+      "S",
+      "L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-112-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-112-urbanmesh/240/180",
+    "created_at": "2025-09-10",
+    "description": "Lightweight yet durable, the Neo Jacket 179 by UrbanMesh delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1113",
+    "name": "Zen Pack 424",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 117.71,
+    "rating": 4.9,
+    "reviews": 1425,
+    "colors": [
+      "Gray",
+      "White",
+      "Blue"
+    ],
+    "sizes": [
+      "20L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "limited",
+      "durable",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-113-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-113-urbanmesh/240/180",
+    "created_at": "2025-08-18",
+    "description": "Zen Pack 424 from UrbanMesh is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1114",
+    "name": "Neo Daily 52",
+    "brand": "TrailForge",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 144.93,
+    "rating": 3.7,
+    "reviews": 1975,
+    "colors": [
+      "Forest",
+      "Pink"
+    ],
+    "sizes": [
+      "9",
+      "11",
+      "7",
+      "8",
+      "10",
+      "12"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "new",
+      "limited",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-114-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-114-trailforge/240/180",
+    "created_at": "2024-10-25",
+    "description": "Neo Daily 52 from TrailForge is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1115",
+    "name": "Cumulus Tee 429",
+    "brand": "TrailForge",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 42.61,
+    "rating": 4.2,
+    "reviews": 1918,
+    "colors": [
+      "Black",
+      "Purple",
+      "Olive"
+    ],
+    "sizes": [
+      "M",
+      "XXL",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "durable",
+      "new",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-115-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-115-trailforge/240/180",
+    "created_at": "2025-06-15",
+    "description": "Cumulus Tee 429 from TrailForge is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1116",
+    "name": "Ion Carry 84",
+    "brand": "Voltline",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 143.7,
+    "rating": 4.5,
+    "reviews": 1471,
+    "colors": [
+      "Black",
+      "Volt"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-116-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-116-voltline/240/180",
+    "created_at": "2024-12-17",
+    "description": "Voltline's Ion Carry 84 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1117",
+    "name": "Neo Earbuds 206",
+    "brand": "Seoulistic",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 276.62,
+    "rating": 3.8,
+    "reviews": 287,
+    "colors": [
+      "Volt",
+      "Navy",
+      "Black",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "water-resistant",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-117-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-117-seoulistic/240/180",
+    "created_at": "2025-04-26",
+    "description": "Seoulistic's Neo Earbuds 206 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1118",
+    "name": "Urban Lantern 355",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 109.56,
+    "rating": 4.5,
+    "reviews": 953,
+    "colors": [
+      "Gray",
+      "Forest",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "limited",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-118-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-118-cloudbloc/240/180",
+    "created_at": "2025-09-05",
+    "description": "The Urban Lantern 355 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1119",
+    "name": "Trail Bottle 491",
+    "brand": "PolarGrid",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 16.41,
+    "rating": 3.7,
+    "reviews": 1531,
+    "colors": [
+      "Forest",
+      "Red",
+      "Tan"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-119-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-119-polargrid/240/180",
+    "created_at": "2024-12-30",
+    "description": "Designed for comfort and durability, the Trail Bottle 491 is perfect for accessories needs."
+  },
+  {
+    "id": "sku_1120",
+    "name": "Flux Watch 470",
+    "brand": "Seoulistic",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 315.95,
+    "rating": 3.6,
+    "reviews": 1121,
+    "colors": [
+      "Blue",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight",
+      "limited",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-120-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-120-seoulistic/240/180",
+    "created_at": "2025-02-24",
+    "description": "Flux Watch 470 from Seoulistic is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1121",
+    "name": "Volt Chair 415",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 41.09,
+    "rating": 3.7,
+    "reviews": 850,
+    "colors": [
+      "Blue",
+      "Black",
+      "Red",
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "eco",
+      "water-resistant",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-121-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-121-urbanmesh/240/180",
+    "created_at": "2025-02-14",
+    "description": "The Volt Chair 415 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1122",
+    "name": "Volt Hoodie 217",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 128.91,
+    "rating": 3.6,
+    "reviews": 123,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [
+      "L",
+      "M",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "water-resistant",
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-122-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-122-polargrid/240/180",
+    "created_at": "2025-08-04",
+    "description": "The Volt Hoodie 217 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1123",
+    "name": "Volt Speaker 494",
+    "brand": "TrailForge",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 273.86,
+    "rating": 4.3,
+    "reviews": 1338,
+    "colors": [
+      "White",
+      "Gray",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "best-seller",
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-123-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-123-trailforge/240/180",
+    "created_at": "2024-11-14",
+    "description": "TrailForge's Volt Speaker 494 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1124",
+    "name": "Wave Commuter 273",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 96.2,
+    "rating": 3.8,
+    "reviews": 943,
+    "colors": [
+      "Gray",
+      "Olive",
+      "Navy"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "lightweight",
+      "durable",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-124-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-124-urbanmesh/240/180",
+    "created_at": "2025-08-14",
+    "description": "Designed for comfort and durability, the Wave Commuter 273 is perfect for bags needs."
+  },
+  {
+    "id": "sku_1125",
+    "name": "Tempo Classic 229",
+    "brand": "Northpeak",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 135.76,
+    "rating": 4.6,
+    "reviews": 99,
+    "colors": [
+      "Purple",
+      "Black"
+    ],
+    "sizes": [
+      "9",
+      "7",
+      "10",
+      "11",
+      "6",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-125-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-125-northpeak/240/180",
+    "created_at": "2025-02-05",
+    "description": "Lightweight yet durable, the Tempo Classic 229 by Northpeak delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1126",
+    "name": "Trail Lantern 449",
+    "brand": "AuroraLab",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 74.3,
+    "rating": 4.5,
+    "reviews": 452,
+    "colors": [
+      "Olive",
+      "Purple",
+      "Black",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "new",
+      "eco",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-126-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-126-auroralab/240/180",
+    "created_at": "2024-12-08",
+    "description": "Trail Lantern 449 from AuroraLab is a versatile outdoors built for everyday use."
+  },
+  {
+    "id": "sku_1127",
+    "name": "Summit Flask 357",
+    "brand": "TrailForge",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 25.74,
+    "rating": 3.7,
+    "reviews": 770,
+    "colors": [
+      "Red",
+      "Tan"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "best-seller",
+      "eco",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-127-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-127-trailforge/240/180",
+    "created_at": "2025-02-10",
+    "description": "Summit Flask 357 from TrailForge is a versatile accessories built for everyday use."
+  },
+  {
+    "id": "sku_1128",
+    "name": "Pulse Pan 199",
+    "brand": "TrailForge",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 43.76,
+    "rating": 3.8,
+    "reviews": 1324,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "lightweight",
+      "water-resistant",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-128-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-128-trailforge/240/180",
+    "created_at": "2024-10-27",
+    "description": "Designed for comfort and durability, the Pulse Pan 199 is perfect for home needs."
+  },
+  {
+    "id": "sku_1129",
+    "name": "Nimbus Tent 97",
+    "brand": "PolarGrid",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 324.96,
+    "rating": 4.4,
+    "reviews": 1375,
+    "colors": [
+      "Tan",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "durable",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-129-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-129-polargrid/240/180",
+    "created_at": "2025-02-27",
+    "description": "Designed for comfort and durability, the Nimbus Tent 97 is perfect for outdoors needs."
+  },
+  {
+    "id": "sku_1130",
+    "name": "Trail Street 204",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 170.66,
+    "rating": 4.3,
+    "reviews": 1588,
+    "colors": [
+      "Forest",
+      "Tan",
+      "Red"
+    ],
+    "sizes": [
+      "8",
+      "12",
+      "11",
+      "9",
+      "7"
+    ],
+    "in_stock": false,
+    "tags": [
+      "eco",
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-130-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-130-urbanmesh/240/180",
+    "created_at": "2025-05-08",
+    "description": "Designed for comfort and durability, the Trail Street 204 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1131",
+    "name": "Aero Earbuds 380",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 82.99,
+    "rating": 3.9,
+    "reviews": 1914,
+    "colors": [
+      "Olive",
+      "Gray",
+      "Navy",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-131-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-131-cloudbloc/240/180",
+    "created_at": "2025-06-28",
+    "description": "Cloudbloc's Aero Earbuds 380 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1132",
+    "name": "Atlas Flask 236",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 17.55,
+    "rating": 4.7,
+    "reviews": 346,
+    "colors": [
+      "Purple",
+      "Red"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new",
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-132-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-132-nimbusworks/240/180",
+    "created_at": "2025-06-14",
+    "description": "The Atlas Flask 236 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1133",
+    "name": "Pulse Fly 432",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 171.99,
+    "rating": 3.6,
+    "reviews": 309,
+    "colors": [
+      "Navy"
+    ],
+    "sizes": [
+      "9",
+      "8",
+      "6",
+      "12",
+      "11",
+      "7",
+      "10"
+    ],
+    "in_stock": false,
+    "tags": [
+      "lightweight",
+      "2025",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-133-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-133-cloudbloc/240/180",
+    "created_at": "2025-06-19",
+    "description": "The Pulse Fly 432 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1134",
+    "name": "Polar Daypack 258",
+    "brand": "Seoulistic",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 154.78,
+    "rating": 4.5,
+    "reviews": 1651,
+    "colors": [
+      "White",
+      "Purple"
+    ],
+    "sizes": [
+      "20L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "best-seller",
+      "water-resistant",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-134-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-134-seoulistic/240/180",
+    "created_at": "2025-07-24",
+    "description": "Lightweight yet durable, the Polar Daypack 258 by Seoulistic delivers outstanding quality for bags enthusiasts."
+  },
+  {
+    "id": "sku_1135",
+    "name": "Flux Headphones 236",
+    "brand": "Northpeak",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 238.05,
+    "rating": 5.0,
+    "reviews": 462,
+    "colors": [
+      "Pink",
+      "White",
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "2025",
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-135-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-135-northpeak/240/180",
+    "created_at": "2025-03-23",
+    "description": "The Flux Headphones 236 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1136",
+    "name": "Volt Sprint 433",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 146.41,
+    "rating": 4.7,
+    "reviews": 1158,
+    "colors": [
+      "Red"
+    ],
+    "sizes": [
+      "7",
+      "12",
+      "10"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-136-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-136-zenwave/240/180",
+    "created_at": "2024-10-03",
+    "description": "Designed for comfort and durability, the Volt Sprint 433 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1137",
+    "name": "Cumulus Lantern 9",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 384.4,
+    "rating": 4.4,
+    "reviews": 1540,
+    "colors": [
+      "White",
+      "Olive",
+      "Gray",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "eco",
+      "2025",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-137-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-137-cloudbloc/240/180",
+    "created_at": "2025-03-28",
+    "description": "Lightweight yet durable, the Cumulus Lantern 9 by Cloudbloc delivers outstanding quality for outdoors enthusiasts."
+  },
+  {
+    "id": "sku_1138",
+    "name": "Flux Classic 51",
+    "brand": "Seoulistic",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 118.08,
+    "rating": 4.8,
+    "reviews": 697,
+    "colors": [
+      "Volt",
+      "Black",
+      "Olive",
+      "Tan"
+    ],
+    "sizes": [
+      "7",
+      "8",
+      "10",
+      "9",
+      "12",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "best-seller",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-138-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-138-seoulistic/240/180",
+    "created_at": "2025-08-14",
+    "description": "Lightweight yet durable, the Flux Classic 51 by Seoulistic delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1139",
+    "name": "Volt Daypack 138",
+    "brand": "Voltline",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 65.82,
+    "rating": 4.6,
+    "reviews": 1298,
+    "colors": [
+      "Purple",
+      "Forest"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-139-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-139-voltline/240/180",
+    "created_at": "2024-10-26",
+    "description": "Lightweight yet durable, the Volt Daypack 138 by Voltline delivers outstanding quality for bags enthusiasts."
+  },
+  {
+    "id": "sku_1140",
+    "name": "Ion Bottle 45",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 18.18,
+    "rating": 4.2,
+    "reviews": 1136,
+    "colors": [
+      "White",
+      "Black",
+      "Purple",
+      "Volt"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "best-seller",
+      "lightweight",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-140-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-140-nimbusworks/240/180",
+    "created_at": "2025-07-13",
+    "description": "Ion Bottle 45 from NimbusWorks is a versatile accessories built for everyday use."
+  },
+  {
+    "id": "sku_1141",
+    "name": "Volt Speaker 462",
+    "brand": "TrailForge",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 236.03,
+    "rating": 5.0,
+    "reviews": 497,
+    "colors": [
+      "Pink",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-141-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-141-trailforge/240/180",
+    "created_at": "2025-01-25",
+    "description": "Designed for comfort and durability, the Volt Speaker 462 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1142",
+    "name": "Pulse Prime 216",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 102.97,
+    "rating": 4.7,
+    "reviews": 739,
+    "colors": [
+      "Navy",
+      "Pink",
+      "Tan"
+    ],
+    "sizes": [
+      "10",
+      "7",
+      "9",
+      "6",
+      "12",
+      "11",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "2025",
+      "water-resistant",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-142-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-142-zenwave/240/180",
+    "created_at": "2025-02-27",
+    "description": "Pulse Prime 216 from Zenwave is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1143",
+    "name": "Tempo Bottle 154",
+    "brand": "TrailForge",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 22.58,
+    "rating": 4.9,
+    "reviews": 411,
+    "colors": [
+      "Volt",
+      "Gray",
+      "Forest",
+      "Purple"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "water-resistant",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-143-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-143-trailforge/240/180",
+    "created_at": "2025-07-31",
+    "description": "Lightweight yet durable, the Tempo Bottle 154 by TrailForge delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1144",
+    "name": "Flux Daypack 478",
+    "brand": "TrailForge",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 121.12,
+    "rating": 4.4,
+    "reviews": 1117,
+    "colors": [
+      "Pink",
+      "Red"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "2025",
+      "water-resistant",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-144-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-144-trailforge/240/180",
+    "created_at": "2025-05-04",
+    "description": "Flux Daypack 478 from TrailForge is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1145",
+    "name": "Stratus Speaker 156",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 118.55,
+    "rating": 4.5,
+    "reviews": 1464,
+    "colors": [
+      "Forest",
+      "White",
+      "Tan",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "new",
+      "lightweight",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-145-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-145-urbanmesh/240/180",
+    "created_at": "2025-06-10",
+    "description": "Designed for comfort and durability, the Stratus Speaker 156 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1146",
+    "name": "Volt Kettle 394",
+    "brand": "PolarGrid",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 44.5,
+    "rating": 4.5,
+    "reviews": 340,
+    "colors": [
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "2025",
+      "water-resistant",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-146-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-146-polargrid/240/180",
+    "created_at": "2025-08-22",
+    "description": "The Volt Kettle 394 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1147",
+    "name": "Ion Prime 114",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 126.17,
+    "rating": 4.3,
+    "reviews": 1188,
+    "colors": [
+      "Tan",
+      "Volt"
+    ],
+    "sizes": [
+      "9",
+      "11",
+      "10",
+      "7",
+      "12",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-147-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-147-cloudbloc/240/180",
+    "created_at": "2025-02-08",
+    "description": "Cloudbloc's Ion Prime 114 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1148",
+    "name": "Polar Crew 234",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 66.62,
+    "rating": 4.3,
+    "reviews": 713,
+    "colors": [
+      "White",
+      "Tan",
+      "Pink",
+      "Volt"
+    ],
+    "sizes": [
+      "M",
+      "XS",
+      "XL"
+    ],
+    "in_stock": false,
+    "tags": [
+      "durable",
+      "limited",
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-148-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-148-auroralab/240/180",
+    "created_at": "2025-03-04",
+    "description": "Lightweight yet durable, the Polar Crew 234 by AuroraLab delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1149",
+    "name": "Wave Pan 170",
+    "brand": "Zenwave",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 87.82,
+    "rating": 4.9,
+    "reviews": 474,
+    "colors": [
+      "Pink",
+      "Gray",
+      "Purple",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-149-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-149-zenwave/240/180",
+    "created_at": "2025-07-21",
+    "description": "Wave Pan 170 from Zenwave is a versatile home built for everyday use."
+  },
+  {
+    "id": "sku_1150",
+    "name": "Aurora Speaker 110 · 한정판",
+    "brand": "TrailForge",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 105.14,
+    "rating": 4.6,
+    "reviews": 1656,
+    "colors": [
+      "Blue",
+      "네이비",
+      "블랙"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "limited",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-150-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-150-trailforge/240/180",
+    "created_at": "2025-06-11",
+    "description": "Designed for comfort and durability, the Aurora Speaker 110 · 한정판 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1151",
+    "name": "Ion Puffer 344",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 232.53,
+    "rating": 4.3,
+    "reviews": 1308,
+    "colors": [
+      "Blue",
+      "Forest",
+      "Purple"
+    ],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "2025",
+      "best-seller",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-151-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-151-urbanmesh/240/180",
+    "created_at": "2025-08-20",
+    "description": "Lightweight yet durable, the Ion Puffer 344 by UrbanMesh delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1152",
+    "name": "Ion Tech Tee 157",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 25.25,
+    "rating": 4.1,
+    "reviews": 289,
+    "colors": [
+      "Forest",
+      "Blue",
+      "Gray",
+      "Purple"
+    ],
+    "sizes": [
+      "S",
+      "L",
+      "XXL",
+      "M",
+      "XS",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "new",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-152-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-152-auroralab/240/180",
+    "created_at": "2024-12-14",
+    "description": "AuroraLab's Ion Tech Tee 157 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1153",
+    "name": "Atlas Bottle 100",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 38.9,
+    "rating": 4.9,
+    "reviews": 1035,
+    "colors": [
+      "Forest",
+      "Pink",
+      "Tan",
+      "Purple"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-153-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-153-cloudbloc/240/180",
+    "created_at": "2025-05-18",
+    "description": "Designed for comfort and durability, the Atlas Bottle 100 is perfect for accessories needs."
+  },
+  {
+    "id": "sku_1154",
+    "name": "Polar Runner 141",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 119.23,
+    "rating": 3.9,
+    "reviews": 1598,
+    "colors": [
+      "Blue",
+      "Tan",
+      "Red",
+      "Purple"
+    ],
+    "sizes": [
+      "10",
+      "6",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "best-seller",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-154-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-154-voltline/240/180",
+    "created_at": "2025-03-16",
+    "description": "Lightweight yet durable, the Polar Runner 141 by Voltline delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1155",
+    "name": "Pulse Kettle 377",
+    "brand": "Voltline",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 125.38,
+    "rating": 4.6,
+    "reviews": 609,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-155-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-155-voltline/240/180",
+    "created_at": "2024-10-24",
+    "description": "Designed for comfort and durability, the Pulse Kettle 377 is perfect for home needs."
+  },
+  {
+    "id": "sku_1156",
+    "name": "Flux Anorak 324",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 145.63,
+    "rating": 4.4,
+    "reviews": 1607,
+    "colors": [
+      "Navy",
+      "Black"
+    ],
+    "sizes": [
+      "L",
+      "XL",
+      "S",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-156-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-156-polargrid/240/180",
+    "created_at": "2025-02-06",
+    "description": "The Flux Anorak 324 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1157",
+    "name": "Pulse Classic 142",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 165.38,
+    "rating": 3.7,
+    "reviews": 1773,
+    "colors": [
+      "Navy",
+      "Gray"
+    ],
+    "sizes": [
+      "12",
+      "7",
+      "9",
+      "10",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "eco",
+      "2025",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-157-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-157-zenwave/240/180",
+    "created_at": "2025-01-25",
+    "description": "The Pulse Classic 142 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1158",
+    "name": "Summit Prime 356",
+    "brand": "TrailForge",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 173.0,
+    "rating": 4.1,
+    "reviews": 1946,
+    "colors": [
+      "Volt",
+      "Blue",
+      "Black",
+      "White"
+    ],
+    "sizes": [
+      "11",
+      "12",
+      "8",
+      "6",
+      "10",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-158-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-158-trailforge/240/180",
+    "created_at": "2025-04-17",
+    "description": "The Summit Prime 356 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1159",
+    "name": "Neo Bottle 290",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 40.13,
+    "rating": 4.7,
+    "reviews": 1831,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-159-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-159-nimbusworks/240/180",
+    "created_at": "2025-05-03",
+    "description": "Neo Bottle 290 from NimbusWorks is a versatile accessories built for everyday use."
+  },
+  {
+    "id": "sku_1160",
+    "name": "Glide Tee 491",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 44.52,
+    "rating": 5.0,
+    "reviews": 1862,
+    "colors": [
+      "Pink",
+      "Olive"
+    ],
+    "sizes": [
+      "M",
+      "XS",
+      "XXL",
+      "S"
+    ],
+    "in_stock": false,
+    "tags": [
+      "water-resistant",
+      "lightweight",
+      "eco",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-160-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-160-urbanmesh/240/180",
+    "created_at": "2025-08-16",
+    "description": "UrbanMesh's Glide Tee 491 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1161",
+    "name": "Volt Hoodie 1",
+    "brand": "TrailForge",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 102.68,
+    "rating": 3.6,
+    "reviews": 1215,
+    "colors": [
+      "Red",
+      "Pink"
+    ],
+    "sizes": [
+      "S",
+      "XL",
+      "M",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "eco",
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-161-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-161-trailforge/240/180",
+    "created_at": "2025-04-14",
+    "description": "Designed for comfort and durability, the Volt Hoodie 1 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1162",
+    "name": "Ion Earbuds 161",
+    "brand": "Northpeak",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 165.0,
+    "rating": 3.9,
+    "reviews": 783,
+    "colors": [
+      "Pink",
+      "Purple"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new",
+      "limited",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-162-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-162-northpeak/240/180",
+    "created_at": "2025-06-08",
+    "description": "Lightweight yet durable, the Ion Earbuds 161 by Northpeak delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1163",
+    "name": "Zen Tracker 384",
+    "brand": "AuroraLab",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 142.58,
+    "rating": 4.1,
+    "reviews": 1406,
+    "colors": [
+      "Navy",
+      "White",
+      "Pink",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "water-resistant",
+      "eco",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-163-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-163-auroralab/240/180",
+    "created_at": "2025-07-08",
+    "description": "Lightweight yet durable, the Zen Tracker 384 by AuroraLab delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1164",
+    "name": "Urban Tee 128",
+    "brand": "Voltline",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 52.31,
+    "rating": 4.4,
+    "reviews": 1244,
+    "colors": [
+      "Purple",
+      "Black",
+      "Olive"
+    ],
+    "sizes": [
+      "XL",
+      "XXL",
+      "S",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-164-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-164-voltline/240/180",
+    "created_at": "2025-08-06",
+    "description": "Voltline's Urban Tee 128 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1165",
+    "name": "Trail Headphones 327",
+    "brand": "Northpeak",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 248.75,
+    "rating": 4.3,
+    "reviews": 24,
+    "colors": [
+      "Volt",
+      "Gray",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "new",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-165-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-165-northpeak/240/180",
+    "created_at": "2025-06-28",
+    "description": "Northpeak's Trail Headphones 327 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1166",
+    "name": "Volt Tee 301",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 22.19,
+    "rating": 3.9,
+    "reviews": 81,
+    "colors": [
+      "Forest"
+    ],
+    "sizes": [
+      "XXL",
+      "XL",
+      "L",
+      "S",
+      "M"
+    ],
+    "in_stock": false,
+    "tags": [
+      "water-resistant",
+      "2025",
+      "lightweight",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-166-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-166-urbanmesh/240/180",
+    "created_at": "2025-06-11",
+    "description": "Lightweight yet durable, the Volt Tee 301 by UrbanMesh delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1167",
+    "name": "Zen Street 275",
+    "brand": "Seoulistic",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 105.94,
+    "rating": 4.4,
+    "reviews": 1563,
+    "colors": [
+      "Olive"
+    ],
+    "sizes": [
+      "11",
+      "7",
+      "6",
+      "12",
+      "10",
+      "9"
+    ],
+    "in_stock": false,
+    "tags": [
+      "lightweight",
+      "water-resistant",
+      "limited",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-167-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-167-seoulistic/240/180",
+    "created_at": "2025-07-20",
+    "description": "Lightweight yet durable, the Zen Street 275 by Seoulistic delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1168",
+    "name": "Stratus Classic 84",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 124.61,
+    "rating": 4.0,
+    "reviews": 1059,
+    "colors": [
+      "Gray",
+      "Volt",
+      "Purple"
+    ],
+    "sizes": [
+      "11",
+      "6",
+      "12",
+      "8",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "eco",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-168-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-168-cloudbloc/240/180",
+    "created_at": "2024-10-12",
+    "description": "Lightweight yet durable, the Stratus Classic 84 by Cloudbloc delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1169",
+    "name": "Nimbus Knife Set 440",
+    "brand": "AuroraLab",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 88.8,
+    "rating": 4.1,
+    "reviews": 522,
+    "colors": [
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-169-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-169-auroralab/240/180",
+    "created_at": "2024-11-08",
+    "description": "The Nimbus Knife Set 440 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1170",
+    "name": "Nimbus Sprint 187",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 139.79,
+    "rating": 3.7,
+    "reviews": 1907,
+    "colors": [
+      "Red"
+    ],
+    "sizes": [
+      "7",
+      "8",
+      "12",
+      "9",
+      "11",
+      "10"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "lightweight",
+      "new",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-170-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-170-voltline/240/180",
+    "created_at": "2024-10-19",
+    "description": "Lightweight yet durable, the Nimbus Sprint 187 by Voltline delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1171",
+    "name": "Summit Tee 489",
+    "brand": "Voltline",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 42.86,
+    "rating": 4.8,
+    "reviews": 1773,
+    "colors": [
+      "Olive",
+      "Volt",
+      "White"
+    ],
+    "sizes": [
+      "XS",
+      "M",
+      "S",
+      "L",
+      "XL",
+      "XXL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-171-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-171-voltline/240/180",
+    "created_at": "2025-07-09",
+    "description": "Lightweight yet durable, the Summit Tee 489 by Voltline delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1172",
+    "name": "Aurora Jacket 13",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 106.6,
+    "rating": 4.0,
+    "reviews": 1719,
+    "colors": [
+      "Volt"
+    ],
+    "sizes": [
+      "XL",
+      "L",
+      "M"
+    ],
+    "in_stock": false,
+    "tags": [
+      "best-seller",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-172-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-172-zenwave/240/180",
+    "created_at": "2025-06-08",
+    "description": "The Aurora Jacket 13 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1173",
+    "name": "Urban Runner 23",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 209.77,
+    "rating": 4.8,
+    "reviews": 1064,
+    "colors": [
+      "Purple",
+      "Volt",
+      "Tan",
+      "White"
+    ],
+    "sizes": [
+      "6",
+      "10",
+      "7",
+      "9",
+      "12",
+      "8",
+      "11"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-173-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-173-zenwave/240/180",
+    "created_at": "2024-11-15",
+    "description": "The Urban Runner 23 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1174",
+    "name": "Neo Flask 232",
+    "brand": "TrailForge",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 20.97,
+    "rating": 3.6,
+    "reviews": 415,
+    "colors": [
+      "Blue",
+      "White"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": false,
+    "tags": [
+      "limited",
+      "eco",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-174-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-174-trailforge/240/180",
+    "created_at": "2025-04-28",
+    "description": "Neo Flask 232 from TrailForge is a versatile accessories built for everyday use."
+  },
+  {
+    "id": "sku_1175",
+    "name": "Zen Knife Set 158",
+    "brand": "AuroraLab",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 74.41,
+    "rating": 4.8,
+    "reviews": 185,
+    "colors": [
+      "Pink",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "durable",
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-175-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-175-auroralab/240/180",
+    "created_at": "2025-09-01",
+    "description": "AuroraLab's Zen Knife Set 158 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1176",
+    "name": "Flux Daily 263",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 75.38,
+    "rating": 3.9,
+    "reviews": 1679,
+    "colors": [
+      "Black",
+      "Forest"
+    ],
+    "sizes": [
+      "10",
+      "11",
+      "12",
+      "7",
+      "6",
+      "9"
+    ],
+    "in_stock": false,
+    "tags": [
+      "lightweight",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-176-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-176-voltline/240/180",
+    "created_at": "2024-11-20",
+    "description": "Lightweight yet durable, the Flux Daily 263 by Voltline delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1177",
+    "name": "Zen Jacket 191",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 197.26,
+    "rating": 4.9,
+    "reviews": 172,
+    "colors": [
+      "White",
+      "Black",
+      "Purple"
+    ],
+    "sizes": [
+      "XL",
+      "S",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-177-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-177-zenwave/240/180",
+    "created_at": "2025-02-26",
+    "description": "Designed for comfort and durability, the Zen Jacket 191 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1178",
+    "name": "Aero Sprint 421",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 184.18,
+    "rating": 4.2,
+    "reviews": 783,
+    "colors": [
+      "Gray",
+      "Volt",
+      "Navy",
+      "Purple"
+    ],
+    "sizes": [
+      "8",
+      "9",
+      "7",
+      "6",
+      "12"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco",
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-178-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-178-zenwave/240/180",
+    "created_at": "2025-01-13",
+    "description": "The Aero Sprint 421 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1179",
+    "name": "Volt Band 197",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 136.64,
+    "rating": 3.8,
+    "reviews": 1811,
+    "colors": [
+      "Pink",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "eco",
+      "new",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-179-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-179-cloudbloc/240/180",
+    "created_at": "2025-03-24",
+    "description": "Volt Band 197 from Cloudbloc is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1180",
+    "name": "Summit Flask 199",
+    "brand": "PolarGrid",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 20.92,
+    "rating": 3.5,
+    "reviews": 1222,
+    "colors": [
+      "Black",
+      "Olive"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller",
+      "new",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-180-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-180-polargrid/240/180",
+    "created_at": "2025-05-09",
+    "description": "PolarGrid's Summit Flask 199 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1181",
+    "name": "Trail Tech Tee 137",
+    "brand": "Northpeak",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 51.09,
+    "rating": 4.7,
+    "reviews": 1509,
+    "colors": [
+      "Navy"
+    ],
+    "sizes": [
+      "M",
+      "S",
+      "XL",
+      "XS",
+      "L",
+      "XXL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "new",
+      "best-seller",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-181-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-181-northpeak/240/180",
+    "created_at": "2024-09-24",
+    "description": "Designed for comfort and durability, the Trail Tech Tee 137 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1182",
+    "name": "Atlas Lantern 90",
+    "brand": "Voltline",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 205.88,
+    "rating": 3.6,
+    "reviews": 476,
+    "colors": [
+      "Black",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "best-seller",
+      "durable",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-182-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-182-voltline/240/180",
+    "created_at": "2025-02-26",
+    "description": "Designed for comfort and durability, the Atlas Lantern 90 is perfect for outdoors needs."
+  },
+  {
+    "id": "sku_1183",
+    "name": "Nimbus Tee 76",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 54.37,
+    "rating": 4.9,
+    "reviews": 1585,
+    "colors": [
+      "Red"
+    ],
+    "sizes": [
+      "XS",
+      "M",
+      "L",
+      "XL",
+      "XXL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-183-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-183-auroralab/240/180",
+    "created_at": "2025-02-22",
+    "description": "AuroraLab's Nimbus Tee 76 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1184",
+    "name": "Neo Earbuds 363",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 387.43,
+    "rating": 4.5,
+    "reviews": 1902,
+    "colors": [
+      "Navy",
+      "Pink",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "durable",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-184-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-184-urbanmesh/240/180",
+    "created_at": "2025-03-22",
+    "description": "Neo Earbuds 363 from UrbanMesh is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1185",
+    "name": "Echo Racer 17",
+    "brand": "PolarGrid",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 113.67,
+    "rating": 4.0,
+    "reviews": 1656,
+    "colors": [
+      "Pink",
+      "Blue"
+    ],
+    "sizes": [
+      "9",
+      "7",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "durable",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-185-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-185-polargrid/240/180",
+    "created_at": "2025-01-09",
+    "description": "PolarGrid's Echo Racer 17 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1186",
+    "name": "Glide Classic 136",
+    "brand": "AuroraLab",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 93.07,
+    "rating": 4.5,
+    "reviews": 717,
+    "colors": [
+      "White",
+      "Black",
+      "Pink"
+    ],
+    "sizes": [
+      "9",
+      "11",
+      "12",
+      "7",
+      "10",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "lightweight",
+      "eco",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-186-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-186-auroralab/240/180",
+    "created_at": "2025-03-08",
+    "description": "Lightweight yet durable, the Glide Classic 136 by AuroraLab delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1187",
+    "name": "Glide Hoodie 410",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 229.15,
+    "rating": 3.9,
+    "reviews": 652,
+    "colors": [
+      "White",
+      "Purple",
+      "Volt"
+    ],
+    "sizes": [
+      "XL",
+      "S",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "limited",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-187-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-187-zenwave/240/180",
+    "created_at": "2024-10-27",
+    "description": "Glide Hoodie 410 from Zenwave is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1188",
+    "name": "Tempo Headphones 81",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 48.82,
+    "rating": 4.0,
+    "reviews": 1995,
+    "colors": [
+      "Forest",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "water-resistant",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-188-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-188-zenwave/240/180",
+    "created_at": "2025-06-13",
+    "description": "The Tempo Headphones 81 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1189",
+    "name": "Echo Daily 79",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 76.0,
+    "rating": 3.5,
+    "reviews": 179,
+    "colors": [
+      "Pink",
+      "Purple",
+      "Blue"
+    ],
+    "sizes": [
+      "7",
+      "6",
+      "11",
+      "12",
+      "10",
+      "9"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-189-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-189-cloudbloc/240/180",
+    "created_at": "2025-05-10",
+    "description": "Lightweight yet durable, the Echo Daily 79 by Cloudbloc delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1190",
+    "name": "Atlas Speaker 136",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 62.72,
+    "rating": 4.3,
+    "reviews": 378,
+    "colors": [
+      "Forest",
+      "Volt",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "water-resistant",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-190-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-190-urbanmesh/240/180",
+    "created_at": "2025-01-22",
+    "description": "Designed for comfort and durability, the Atlas Speaker 136 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1191",
+    "name": "Nimbus Pack 386",
+    "brand": "PolarGrid",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 139.02,
+    "rating": 3.6,
+    "reviews": 1368,
+    "colors": [
+      "Red",
+      "Forest",
+      "Blue"
+    ],
+    "sizes": [
+      "20L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "new",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-191-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-191-polargrid/240/180",
+    "created_at": "2025-03-27",
+    "description": "Nimbus Pack 386 from PolarGrid is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1192",
+    "name": "Atlas Lantern 41",
+    "brand": "Voltline",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 169.63,
+    "rating": 4.8,
+    "reviews": 71,
+    "colors": [
+      "White",
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-192-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-192-voltline/240/180",
+    "created_at": "2024-12-04",
+    "description": "Atlas Lantern 41 from Voltline is a versatile outdoors built for everyday use."
+  },
+  {
+    "id": "sku_1193",
+    "name": "Volt Sprint 104",
+    "brand": "TrailForge",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 219.64,
+    "rating": 4.4,
+    "reviews": 1708,
+    "colors": [
+      "Volt",
+      "White",
+      "Pink"
+    ],
+    "sizes": [
+      "10",
+      "9",
+      "12",
+      "8",
+      "7",
+      "11"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "lightweight",
+      "eco",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-193-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-193-trailforge/240/180",
+    "created_at": "2024-09-16",
+    "description": "The Volt Sprint 104 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1194",
+    "name": "Aero Tee 474",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 24.55,
+    "rating": 4.7,
+    "reviews": 1609,
+    "colors": [
+      "Red",
+      "Volt",
+      "Forest"
+    ],
+    "sizes": [
+      "L",
+      "XXL",
+      "XL",
+      "XS",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "lightweight",
+      "eco",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-194-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-194-polargrid/240/180",
+    "created_at": "2024-11-22",
+    "description": "Aero Tee 474 from PolarGrid is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1195",
+    "name": "Atlas Puffer 460",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 134.49,
+    "rating": 4.0,
+    "reviews": 1625,
+    "colors": [
+      "Olive",
+      "Purple",
+      "Tan"
+    ],
+    "sizes": [
+      "M",
+      "S",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-195-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-195-cloudbloc/240/180",
+    "created_at": "2025-04-24",
+    "description": "Atlas Puffer 460 from Cloudbloc is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1196",
+    "name": "Zen Chair 109",
+    "brand": "Northpeak",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 366.19,
+    "rating": 4.1,
+    "reviews": 992,
+    "colors": [
+      "Black",
+      "Red",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "best-seller",
+      "durable",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-196-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-196-northpeak/240/180",
+    "created_at": "2025-09-08",
+    "description": "Zen Chair 109 from Northpeak is a versatile outdoors built for everyday use."
+  },
+  {
+    "id": "sku_1197",
+    "name": "Zen Fly 429",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 97.49,
+    "rating": 3.5,
+    "reviews": 103,
+    "colors": [
+      "Purple",
+      "Navy",
+      "Olive"
+    ],
+    "sizes": [
+      "12",
+      "9",
+      "10",
+      "11",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-197-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-197-zenwave/240/180",
+    "created_at": "2025-08-24",
+    "description": "Lightweight yet durable, the Zen Fly 429 by Zenwave delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1198",
+    "name": "Glide Watch 492",
+    "brand": "PolarGrid",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 444.6,
+    "rating": 4.4,
+    "reviews": 716,
+    "colors": [
+      "Gray",
+      "Olive",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-198-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-198-polargrid/240/180",
+    "created_at": "2025-03-26",
+    "description": "The Glide Watch 492 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1199",
+    "name": "Trail Stove 347",
+    "brand": "Voltline",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 98.35,
+    "rating": 4.5,
+    "reviews": 1051,
+    "colors": [
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "water-resistant",
+      "new",
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-199-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-199-voltline/240/180",
+    "created_at": "2024-11-16",
+    "description": "The Trail Stove 347 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1200",
+    "name": "Polar Carry 217 · 한정판",
+    "brand": "PolarGrid",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 165.89,
+    "rating": 4.8,
+    "reviews": 940,
+    "colors": [
+      "블랙",
+      "Tan",
+      "네이비",
+      "Olive",
+      "Navy"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "new",
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-200-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-200-polargrid/240/180",
+    "created_at": "2024-09-13",
+    "description": "The Polar Carry 217 · 한정판 combines modern style with reliable performance in bags gear."
+  },
+  {
+    "id": "sku_1201",
+    "name": "Polar Tent 247",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 44.19,
+    "rating": 5.0,
+    "reviews": 1311,
+    "colors": [
+      "Olive",
+      "Purple",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-201-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-201-nimbusworks/240/180",
+    "created_at": "2025-06-01",
+    "description": "The Polar Tent 247 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1202",
+    "name": "Neo Stove 370",
+    "brand": "TrailForge",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 29.65,
+    "rating": 4.2,
+    "reviews": 605,
+    "colors": [
+      "Forest",
+      "Purple",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "water-resistant",
+      "limited",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-202-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-202-trailforge/240/180",
+    "created_at": "2025-07-05",
+    "description": "TrailForge's Neo Stove 370 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1203",
+    "name": "Flux Mug 433",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 33.63,
+    "rating": 4.5,
+    "reviews": 1143,
+    "colors": [
+      "Olive",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "limited",
+      "2025",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-203-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-203-urbanmesh/240/180",
+    "created_at": "2025-01-20",
+    "description": "The Flux Mug 433 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1204",
+    "name": "Trail Puffer 216",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 217.62,
+    "rating": 4.0,
+    "reviews": 533,
+    "colors": [
+      "Tan",
+      "White",
+      "Purple"
+    ],
+    "sizes": [
+      "S",
+      "M",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-204-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-204-auroralab/240/180",
+    "created_at": "2025-08-24",
+    "description": "The Trail Puffer 216 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1205",
+    "name": "Zen Crew 210",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 79.21,
+    "rating": 4.8,
+    "reviews": 937,
+    "colors": [
+      "Volt",
+      "Gray"
+    ],
+    "sizes": [
+      "L",
+      "M",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-205-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-205-zenwave/240/180",
+    "created_at": "2024-10-09",
+    "description": "Zen Crew 210 from Zenwave is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1206",
+    "name": "Aero Shell 251",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 217.04,
+    "rating": 4.7,
+    "reviews": 265,
+    "colors": [
+      "Pink",
+      "Forest",
+      "Purple",
+      "Blue"
+    ],
+    "sizes": [
+      "XL",
+      "S",
+      "L",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-206-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-206-zenwave/240/180",
+    "created_at": "2024-09-17",
+    "description": "Designed for comfort and durability, the Aero Shell 251 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1207",
+    "name": "Trail Stride 160",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 106.76,
+    "rating": 4.1,
+    "reviews": 1205,
+    "colors": [
+      "Gray",
+      "White",
+      "Black"
+    ],
+    "sizes": [
+      "8",
+      "9",
+      "10",
+      "12",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "water-resistant",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-207-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-207-voltline/240/180",
+    "created_at": "2024-11-17",
+    "description": "Voltline's Trail Stride 160 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1208",
+    "name": "Aurora Tech Tee 115",
+    "brand": "TrailForge",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 63.08,
+    "rating": 3.7,
+    "reviews": 1503,
+    "colors": [
+      "Blue"
+    ],
+    "sizes": [
+      "XS",
+      "M",
+      "XXL",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new",
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-208-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-208-trailforge/240/180",
+    "created_at": "2025-01-18",
+    "description": "Lightweight yet durable, the Aurora Tech Tee 115 by TrailForge delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1209",
+    "name": "Ion Sprint 228",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 139.43,
+    "rating": 4.3,
+    "reviews": 971,
+    "colors": [
+      "Navy",
+      "Pink"
+    ],
+    "sizes": [
+      "8",
+      "9",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "eco",
+      "lightweight",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-209-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-209-cloudbloc/240/180",
+    "created_at": "2025-01-26",
+    "description": "Cloudbloc's Ion Sprint 228 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1210",
+    "name": "Polar Tent 402",
+    "brand": "Northpeak",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 60.27,
+    "rating": 3.8,
+    "reviews": 409,
+    "colors": [
+      "Red",
+      "Navy",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-210-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-210-northpeak/240/180",
+    "created_at": "2025-02-08",
+    "description": "Lightweight yet durable, the Polar Tent 402 by Northpeak delivers outstanding quality for outdoors enthusiasts."
+  },
+  {
+    "id": "sku_1211",
+    "name": "Atlas Band 121",
+    "brand": "Voltline",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 80.15,
+    "rating": 4.5,
+    "reviews": 1857,
+    "colors": [
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-211-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-211-voltline/240/180",
+    "created_at": "2024-11-25",
+    "description": "Atlas Band 121 from Voltline is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1212",
+    "name": "Trail Daily 152",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 99.05,
+    "rating": 3.6,
+    "reviews": 1665,
+    "colors": [
+      "Black",
+      "Olive"
+    ],
+    "sizes": [
+      "12",
+      "11",
+      "8",
+      "9",
+      "10"
+    ],
+    "in_stock": false,
+    "tags": [
+      "water-resistant",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-212-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-212-nimbusworks/240/180",
+    "created_at": "2024-10-03",
+    "description": "The Trail Daily 152 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1213",
+    "name": "Flux Performance Tee 490",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 56.55,
+    "rating": 4.8,
+    "reviews": 190,
+    "colors": [
+      "Volt",
+      "Gray",
+      "White"
+    ],
+    "sizes": [
+      "L",
+      "XXL",
+      "M",
+      "S",
+      "XL",
+      "XS"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-213-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-213-auroralab/240/180",
+    "created_at": "2024-12-04",
+    "description": "Lightweight yet durable, the Flux Performance Tee 490 by AuroraLab delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1214",
+    "name": "Ion Sprint 467",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 166.8,
+    "rating": 4.7,
+    "reviews": 1389,
+    "colors": [
+      "Gray",
+      "Blue",
+      "Forest",
+      "Volt"
+    ],
+    "sizes": [
+      "6",
+      "11",
+      "7",
+      "9",
+      "10",
+      "12",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "lightweight",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-214-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-214-zenwave/240/180",
+    "created_at": "2024-10-12",
+    "description": "The Ion Sprint 467 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1215",
+    "name": "Aero Pan 490",
+    "brand": "PolarGrid",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 103.11,
+    "rating": 4.0,
+    "reviews": 1071,
+    "colors": [
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-215-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-215-polargrid/240/180",
+    "created_at": "2025-01-15",
+    "description": "The Aero Pan 490 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1216",
+    "name": "Wave Speaker 28",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 33.31,
+    "rating": 4.9,
+    "reviews": 1035,
+    "colors": [
+      "Tan",
+      "Gray",
+      "White",
+      "Purple"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-216-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-216-zenwave/240/180",
+    "created_at": "2025-02-26",
+    "description": "Wave Speaker 28 from Zenwave is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1217",
+    "name": "Echo Pan 41",
+    "brand": "TrailForge",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 73.81,
+    "rating": 4.7,
+    "reviews": 917,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "2025",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-217-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-217-trailforge/240/180",
+    "created_at": "2024-11-09",
+    "description": "TrailForge's Echo Pan 41 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1218",
+    "name": "Wave Speaker 1",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 334.59,
+    "rating": 4.7,
+    "reviews": 1972,
+    "colors": [
+      "Red",
+      "Purple",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-218-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-218-cloudbloc/240/180",
+    "created_at": "2025-05-01",
+    "description": "Cloudbloc's Wave Speaker 1 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1219",
+    "name": "Neo Anorak 393",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 183.95,
+    "rating": 4.2,
+    "reviews": 1345,
+    "colors": [
+      "Purple",
+      "Tan",
+      "White"
+    ],
+    "sizes": [
+      "M",
+      "S",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "2025",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-219-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-219-urbanmesh/240/180",
+    "created_at": "2025-07-31",
+    "description": "The Neo Anorak 393 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1220",
+    "name": "Atlas Fly 421",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 183.19,
+    "rating": 4.6,
+    "reviews": 219,
+    "colors": [
+      "Blue",
+      "Navy",
+      "Pink"
+    ],
+    "sizes": [
+      "12",
+      "9",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "lightweight",
+      "eco",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-220-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-220-zenwave/240/180",
+    "created_at": "2024-12-16",
+    "description": "Designed for comfort and durability, the Atlas Fly 421 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1221",
+    "name": "Glide Chair 338",
+    "brand": "Northpeak",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 243.35,
+    "rating": 4.3,
+    "reviews": 1973,
+    "colors": [
+      "Black",
+      "Red",
+      "Purple",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-221-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-221-northpeak/240/180",
+    "created_at": "2025-07-06",
+    "description": "The Glide Chair 338 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1222",
+    "name": "Ion Performance Tee 337",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 55.23,
+    "rating": 4.8,
+    "reviews": 1032,
+    "colors": [
+      "Forest",
+      "Blue",
+      "Navy",
+      "Olive"
+    ],
+    "sizes": [
+      "M",
+      "XXL",
+      "L",
+      "XS",
+      "XL",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-222-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-222-zenwave/240/180",
+    "created_at": "2025-05-30",
+    "description": "Lightweight yet durable, the Ion Performance Tee 337 by Zenwave delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1223",
+    "name": "Zen Pan 320",
+    "brand": "Voltline",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 109.3,
+    "rating": 4.5,
+    "reviews": 1886,
+    "colors": [
+      "Purple",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "2025",
+      "lightweight",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-223-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-223-voltline/240/180",
+    "created_at": "2024-12-10",
+    "description": "Lightweight yet durable, the Zen Pan 320 by Voltline delivers outstanding quality for home enthusiasts."
+  },
+  {
+    "id": "sku_1224",
+    "name": "Aero Knife Set 346",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 113.95,
+    "rating": 4.8,
+    "reviews": 585,
+    "colors": [
+      "Black",
+      "Red",
+      "White",
+      "Purple"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "durable",
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-224-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-224-urbanmesh/240/180",
+    "created_at": "2024-10-07",
+    "description": "Designed for comfort and durability, the Aero Knife Set 346 is perfect for home needs."
+  },
+  {
+    "id": "sku_1225",
+    "name": "Stratus Daypack 354",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 150.89,
+    "rating": 3.8,
+    "reviews": 1108,
+    "colors": [
+      "Volt"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "eco",
+      "limited",
+      "best-seller",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-225-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-225-nimbusworks/240/180",
+    "created_at": "2025-08-21",
+    "description": "The Stratus Daypack 354 combines modern style with reliable performance in bags gear."
+  },
+  {
+    "id": "sku_1226",
+    "name": "Summit Speaker 148",
+    "brand": "Voltline",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 285.39,
+    "rating": 3.6,
+    "reviews": 781,
+    "colors": [
+      "Forest",
+      "Pink",
+      "Volt",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-226-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-226-voltline/240/180",
+    "created_at": "2025-01-16",
+    "description": "Summit Speaker 148 from Voltline is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1227",
+    "name": "Aero Anorak 379",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 180.68,
+    "rating": 4.7,
+    "reviews": 1974,
+    "colors": [
+      "Olive",
+      "Tan"
+    ],
+    "sizes": [
+      "S",
+      "XL",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "eco",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-227-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-227-auroralab/240/180",
+    "created_at": "2024-11-10",
+    "description": "Aero Anorak 379 from AuroraLab is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1228",
+    "name": "Stratus Pan 300",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 127.6,
+    "rating": 3.5,
+    "reviews": 955,
+    "colors": [
+      "Black",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-228-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-228-nimbusworks/240/180",
+    "created_at": "2025-07-12",
+    "description": "Stratus Pan 300 from NimbusWorks is a versatile home built for everyday use."
+  },
+  {
+    "id": "sku_1229",
+    "name": "Flux Tent 402",
+    "brand": "Seoulistic",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 288.21,
+    "rating": 4.3,
+    "reviews": 1959,
+    "colors": [
+      "Red",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "lightweight",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-229-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-229-seoulistic/240/180",
+    "created_at": "2024-11-30",
+    "description": "The Flux Tent 402 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1230",
+    "name": "Neo Puffer 185",
+    "brand": "Voltline",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 118.71,
+    "rating": 4.9,
+    "reviews": 1266,
+    "colors": [
+      "Red",
+      "Pink",
+      "Black",
+      "White"
+    ],
+    "sizes": [
+      "XL",
+      "S",
+      "L",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "eco",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-230-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-230-voltline/240/180",
+    "created_at": "2025-02-21",
+    "description": "Lightweight yet durable, the Neo Puffer 185 by Voltline delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1231",
+    "name": "Aurora Mug 264",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 121.59,
+    "rating": 4.2,
+    "reviews": 89,
+    "colors": [
+      "Pink",
+      "Navy",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-231-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-231-nimbusworks/240/180",
+    "created_at": "2024-10-29",
+    "description": "The Aurora Mug 264 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1232",
+    "name": "Zen Daily 428",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 81.43,
+    "rating": 4.3,
+    "reviews": 1439,
+    "colors": [
+      "Pink",
+      "White",
+      "Gray",
+      "Black"
+    ],
+    "sizes": [
+      "11",
+      "8",
+      "6",
+      "10",
+      "9",
+      "12"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "new",
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-232-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-232-voltline/240/180",
+    "created_at": "2025-01-16",
+    "description": "Zen Daily 428 from Voltline is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1233",
+    "name": "Glide Speaker 208",
+    "brand": "TrailForge",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 189.22,
+    "rating": 3.5,
+    "reviews": 1378,
+    "colors": [
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-233-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-233-trailforge/240/180",
+    "created_at": "2025-07-23",
+    "description": "Designed for comfort and durability, the Glide Speaker 208 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1234",
+    "name": "Summit Classic 149",
+    "brand": "AuroraLab",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 156.56,
+    "rating": 4.0,
+    "reviews": 177,
+    "colors": [
+      "Tan",
+      "Forest",
+      "Pink"
+    ],
+    "sizes": [
+      "9",
+      "7",
+      "10"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "limited",
+      "durable",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-234-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-234-auroralab/240/180",
+    "created_at": "2025-03-29",
+    "description": "AuroraLab's Summit Classic 149 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1235",
+    "name": "Wave Bottle 64",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 13.38,
+    "rating": 4.4,
+    "reviews": 807,
+    "colors": [
+      "Olive"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-235-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-235-cloudbloc/240/180",
+    "created_at": "2025-03-05",
+    "description": "Lightweight yet durable, the Wave Bottle 64 by Cloudbloc delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1236",
+    "name": "Cumulus Pan 114",
+    "brand": "Zenwave",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 95.75,
+    "rating": 3.9,
+    "reviews": 234,
+    "colors": [
+      "Pink",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "water-resistant",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-236-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-236-zenwave/240/180",
+    "created_at": "2025-06-18",
+    "description": "The Cumulus Pan 114 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1237",
+    "name": "Ion Street 372",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 133.87,
+    "rating": 4.9,
+    "reviews": 731,
+    "colors": [
+      "Pink",
+      "Purple"
+    ],
+    "sizes": [
+      "6",
+      "8",
+      "10",
+      "12"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "water-resistant",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-237-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-237-nimbusworks/240/180",
+    "created_at": "2025-02-19",
+    "description": "Ion Street 372 from NimbusWorks is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1238",
+    "name": "Stratus Carry 414",
+    "brand": "PolarGrid",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 87.7,
+    "rating": 4.1,
+    "reviews": 9,
+    "colors": [
+      "Navy",
+      "Purple",
+      "Forest"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "eco",
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-238-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-238-polargrid/240/180",
+    "created_at": "2024-11-17",
+    "description": "The Stratus Carry 414 combines modern style with reliable performance in bags gear."
+  },
+  {
+    "id": "sku_1239",
+    "name": "Atlas Bottle 90",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 33.3,
+    "rating": 3.6,
+    "reviews": 574,
+    "colors": [
+      "Red",
+      "Navy"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-239-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-239-nimbusworks/240/180",
+    "created_at": "2025-07-27",
+    "description": "Designed for comfort and durability, the Atlas Bottle 90 is perfect for accessories needs."
+  },
+  {
+    "id": "sku_1240",
+    "name": "Aero Knife Set 394",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 92.02,
+    "rating": 4.9,
+    "reviews": 1129,
+    "colors": [
+      "Red",
+      "Purple",
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-240-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-240-cloudbloc/240/180",
+    "created_at": "2024-11-25",
+    "description": "Lightweight yet durable, the Aero Knife Set 394 by Cloudbloc delivers outstanding quality for home enthusiasts."
+  },
+  {
+    "id": "sku_1241",
+    "name": "Glide Daypack 204",
+    "brand": "Zenwave",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 94.12,
+    "rating": 3.5,
+    "reviews": 489,
+    "colors": [
+      "Red",
+      "Gray"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "limited",
+      "best-seller",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-241-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-241-zenwave/240/180",
+    "created_at": "2025-06-26",
+    "description": "The Glide Daypack 204 combines modern style with reliable performance in bags gear."
+  },
+  {
+    "id": "sku_1242",
+    "name": "Trail Flask 119",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 14.07,
+    "rating": 4.1,
+    "reviews": 87,
+    "colors": [
+      "Red",
+      "Volt"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-242-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-242-cloudbloc/240/180",
+    "created_at": "2025-04-30",
+    "description": "Trail Flask 119 from Cloudbloc is a versatile accessories built for everyday use."
+  },
+  {
+    "id": "sku_1243",
+    "name": "Summit Flask 428",
+    "brand": "Northpeak",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 36.48,
+    "rating": 4.4,
+    "reviews": 1167,
+    "colors": [
+      "Forest",
+      "Pink"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-243-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-243-northpeak/240/180",
+    "created_at": "2025-08-10",
+    "description": "The Summit Flask 428 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1244",
+    "name": "Echo Puffer 419",
+    "brand": "Seoulistic",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 233.54,
+    "rating": 4.2,
+    "reviews": 987,
+    "colors": [
+      "Red"
+    ],
+    "sizes": [
+      "XL",
+      "S",
+      "L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "eco",
+      "durable",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-244-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-244-seoulistic/240/180",
+    "created_at": "2025-08-05",
+    "description": "Designed for comfort and durability, the Echo Puffer 419 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1245",
+    "name": "Tempo Tee 339",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 32.28,
+    "rating": 4.7,
+    "reviews": 1475,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [
+      "L",
+      "S",
+      "XL",
+      "M",
+      "XXL",
+      "XS"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "durable",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-245-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-245-auroralab/240/180",
+    "created_at": "2024-11-14",
+    "description": "Lightweight yet durable, the Tempo Tee 339 by AuroraLab delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1246",
+    "name": "Stratus Runner 86",
+    "brand": "PolarGrid",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 123.57,
+    "rating": 3.8,
+    "reviews": 1962,
+    "colors": [
+      "Blue",
+      "Purple",
+      "Black",
+      "Olive"
+    ],
+    "sizes": [
+      "7",
+      "9",
+      "10"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-246-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-246-polargrid/240/180",
+    "created_at": "2025-05-14",
+    "description": "The Stratus Runner 86 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1247",
+    "name": "Stratus Speaker 421",
+    "brand": "PolarGrid",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 312.97,
+    "rating": 4.4,
+    "reviews": 1046,
+    "colors": [
+      "Gray",
+      "Pink",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "2025",
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-247-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-247-polargrid/240/180",
+    "created_at": "2025-07-12",
+    "description": "Designed for comfort and durability, the Stratus Speaker 421 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1248",
+    "name": "Aurora Tech Tee 268",
+    "brand": "Northpeak",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 71.29,
+    "rating": 4.3,
+    "reviews": 859,
+    "colors": [
+      "Blue",
+      "White"
+    ],
+    "sizes": [
+      "L",
+      "XL",
+      "XS",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-248-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-248-northpeak/240/180",
+    "created_at": "2024-11-09",
+    "description": "Aurora Tech Tee 268 from Northpeak is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1249",
+    "name": "Wave Tee 460",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 76.14,
+    "rating": 4.5,
+    "reviews": 883,
+    "colors": [
+      "Volt",
+      "Black",
+      "Red",
+      "Forest"
+    ],
+    "sizes": [
+      "L",
+      "XXL",
+      "M",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "eco",
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-249-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-249-polargrid/240/180",
+    "created_at": "2025-09-01",
+    "description": "Designed for comfort and durability, the Wave Tee 460 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1250",
+    "name": "Volt Band 307 · 한정판",
+    "brand": "Voltline",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 447.24,
+    "rating": 4.1,
+    "reviews": 387,
+    "colors": [
+      "블랙",
+      "Purple",
+      "네이비"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "new",
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-250-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-250-voltline/240/180",
+    "created_at": "2024-09-13",
+    "description": "Voltline's Volt Band 307 · 한정판 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1251",
+    "name": "Pulse Puffer 55",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 90.96,
+    "rating": 4.5,
+    "reviews": 519,
+    "colors": [
+      "Red",
+      "Forest",
+      "Blue"
+    ],
+    "sizes": [
+      "L",
+      "XL",
+      "M",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "2025",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-251-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-251-auroralab/240/180",
+    "created_at": "2025-06-22",
+    "description": "The Pulse Puffer 55 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1252",
+    "name": "Urban Mug 296",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 57.87,
+    "rating": 4.6,
+    "reviews": 1506,
+    "colors": [
+      "Pink",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "lightweight",
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-252-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-252-urbanmesh/240/180",
+    "created_at": "2025-04-26",
+    "description": "The Urban Mug 296 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1253",
+    "name": "Wave Speaker 357",
+    "brand": "AuroraLab",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 282.29,
+    "rating": 3.6,
+    "reviews": 796,
+    "colors": [
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "lightweight",
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-253-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-253-auroralab/240/180",
+    "created_at": "2025-05-09",
+    "description": "AuroraLab's Wave Speaker 357 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1254",
+    "name": "Volt Anorak 20",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 204.9,
+    "rating": 4.9,
+    "reviews": 820,
+    "colors": [
+      "Purple",
+      "Blue",
+      "Black"
+    ],
+    "sizes": [
+      "XL",
+      "M",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "durable",
+      "lightweight",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-254-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-254-auroralab/240/180",
+    "created_at": "2025-08-12",
+    "description": "AuroraLab's Volt Anorak 20 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1255",
+    "name": "Trail Pan 346",
+    "brand": "Seoulistic",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 15.01,
+    "rating": 3.9,
+    "reviews": 0,
+    "colors": [
+      "White",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "eco",
+      "new",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-255-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-255-seoulistic/240/180",
+    "created_at": "2025-03-09",
+    "description": "The Trail Pan 346 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1256",
+    "name": "Volt Kettle 282",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 49.54,
+    "rating": 4.7,
+    "reviews": 1873,
+    "colors": [
+      "Volt",
+      "Olive",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "new",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-256-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-256-cloudbloc/240/180",
+    "created_at": "2024-12-18",
+    "description": "Lightweight yet durable, the Volt Kettle 282 by Cloudbloc delivers outstanding quality for home enthusiasts."
+  },
+  {
+    "id": "sku_1257",
+    "name": "Pulse Daypack 287",
+    "brand": "Zenwave",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 54.77,
+    "rating": 3.9,
+    "reviews": 1939,
+    "colors": [
+      "Red"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "eco",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-257-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-257-zenwave/240/180",
+    "created_at": "2025-07-01",
+    "description": "Zenwave's Pulse Daypack 287 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1258",
+    "name": "Neo Band 349",
+    "brand": "Voltline",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 272.5,
+    "rating": 4.4,
+    "reviews": 56,
+    "colors": [
+      "White",
+      "Olive",
+      "Purple",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "best-seller",
+      "water-resistant",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-258-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-258-voltline/240/180",
+    "created_at": "2024-12-31",
+    "description": "Lightweight yet durable, the Neo Band 349 by Voltline delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1259",
+    "name": "Wave Bottle 359",
+    "brand": "Seoulistic",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 39.46,
+    "rating": 3.9,
+    "reviews": 190,
+    "colors": [
+      "Pink",
+      "Volt",
+      "White",
+      "Red"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-259-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-259-seoulistic/240/180",
+    "created_at": "2025-03-10",
+    "description": "Seoulistic's Wave Bottle 359 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1260",
+    "name": "Zen Shell 377",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 108.41,
+    "rating": 3.9,
+    "reviews": 469,
+    "colors": [
+      "Navy",
+      "Blue"
+    ],
+    "sizes": [
+      "M",
+      "S",
+      "L",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "best-seller",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-260-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-260-urbanmesh/240/180",
+    "created_at": "2025-08-15",
+    "description": "The Zen Shell 377 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1261",
+    "name": "Flux Racer 162",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 154.0,
+    "rating": 5.0,
+    "reviews": 1837,
+    "colors": [
+      "Tan",
+      "Gray",
+      "Red"
+    ],
+    "sizes": [
+      "9",
+      "7",
+      "10",
+      "11",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-261-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-261-urbanmesh/240/180",
+    "created_at": "2025-04-14",
+    "description": "UrbanMesh's Flux Racer 162 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1262",
+    "name": "Glide Earbuds 358",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 220.74,
+    "rating": 4.0,
+    "reviews": 17,
+    "colors": [
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-262-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-262-zenwave/240/180",
+    "created_at": "2025-07-04",
+    "description": "Lightweight yet durable, the Glide Earbuds 358 by Zenwave delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1263",
+    "name": "Cumulus Lantern 122",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 122.11,
+    "rating": 4.9,
+    "reviews": 702,
+    "colors": [
+      "Gray",
+      "Tan",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-263-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-263-nimbusworks/240/180",
+    "created_at": "2025-09-03",
+    "description": "Lightweight yet durable, the Cumulus Lantern 122 by NimbusWorks delivers outstanding quality for outdoors enthusiasts."
+  },
+  {
+    "id": "sku_1264",
+    "name": "Cumulus Pack 295",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 137.61,
+    "rating": 4.7,
+    "reviews": 1476,
+    "colors": [
+      "Navy",
+      "Red",
+      "Forest"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "durable",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-264-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-264-urbanmesh/240/180",
+    "created_at": "2024-11-25",
+    "description": "The Cumulus Pack 295 combines modern style with reliable performance in bags gear."
+  },
+  {
+    "id": "sku_1265",
+    "name": "Summit Tracker 369",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 211.61,
+    "rating": 4.2,
+    "reviews": 513,
+    "colors": [
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "eco",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-265-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-265-zenwave/240/180",
+    "created_at": "2024-12-02",
+    "description": "Lightweight yet durable, the Summit Tracker 369 by Zenwave delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1266",
+    "name": "Ion Commuter 382",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 90.18,
+    "rating": 4.0,
+    "reviews": 1147,
+    "colors": [
+      "Volt",
+      "Black",
+      "Forest"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "new",
+      "best-seller",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-266-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-266-urbanmesh/240/180",
+    "created_at": "2025-08-23",
+    "description": "Designed for comfort and durability, the Ion Commuter 382 is perfect for bags needs."
+  },
+  {
+    "id": "sku_1267",
+    "name": "Flux Crew 345",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 49.65,
+    "rating": 4.7,
+    "reviews": 915,
+    "colors": [
+      "Forest"
+    ],
+    "sizes": [
+      "L",
+      "S",
+      "XL",
+      "M",
+      "XXL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "2025",
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-267-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-267-nimbusworks/240/180",
+    "created_at": "2025-07-20",
+    "description": "Designed for comfort and durability, the Flux Crew 345 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1268",
+    "name": "Trail Crew 163",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 58.49,
+    "rating": 4.6,
+    "reviews": 1239,
+    "colors": [
+      "Olive",
+      "Tan",
+      "Volt",
+      "Red"
+    ],
+    "sizes": [
+      "L",
+      "S",
+      "XL",
+      "XS",
+      "M",
+      "XXL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "2025",
+      "best-seller",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-268-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-268-auroralab/240/180",
+    "created_at": "2025-09-03",
+    "description": "Designed for comfort and durability, the Trail Crew 163 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1269",
+    "name": "Volt Daily 281",
+    "brand": "Northpeak",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 75.92,
+    "rating": 4.7,
+    "reviews": 1073,
+    "colors": [
+      "White"
+    ],
+    "sizes": [
+      "10",
+      "7",
+      "6",
+      "9",
+      "11"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-269-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-269-northpeak/240/180",
+    "created_at": "2025-02-02",
+    "description": "The Volt Daily 281 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1270",
+    "name": "Nimbus Crew 441",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 74.75,
+    "rating": 4.8,
+    "reviews": 956,
+    "colors": [
+      "Red",
+      "Tan",
+      "Gray"
+    ],
+    "sizes": [
+      "XL",
+      "XXL",
+      "L",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "water-resistant",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-270-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-270-cloudbloc/240/180",
+    "created_at": "2025-06-25",
+    "description": "Cloudbloc's Nimbus Crew 441 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1271",
+    "name": "Volt Knife Set 158",
+    "brand": "Voltline",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 60.84,
+    "rating": 3.9,
+    "reviews": 621,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-271-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-271-voltline/240/180",
+    "created_at": "2024-11-18",
+    "description": "Designed for comfort and durability, the Volt Knife Set 158 is perfect for home needs."
+  },
+  {
+    "id": "sku_1272",
+    "name": "Atlas Stride 5",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 189.56,
+    "rating": 4.7,
+    "reviews": 1222,
+    "colors": [
+      "Black",
+      "Red"
+    ],
+    "sizes": [
+      "7",
+      "9",
+      "10",
+      "11",
+      "12"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "durable",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-272-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-272-urbanmesh/240/180",
+    "created_at": "2025-08-06",
+    "description": "The Atlas Stride 5 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1273",
+    "name": "Trail Prime 146",
+    "brand": "TrailForge",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 141.33,
+    "rating": 4.3,
+    "reviews": 550,
+    "colors": [
+      "Navy",
+      "White",
+      "Gray",
+      "Blue"
+    ],
+    "sizes": [
+      "6",
+      "11",
+      "9",
+      "10",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-273-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-273-trailforge/240/180",
+    "created_at": "2025-05-19",
+    "description": "Designed for comfort and durability, the Trail Prime 146 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1274",
+    "name": "Wave Tee 96",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 78.28,
+    "rating": 3.9,
+    "reviews": 256,
+    "colors": [
+      "Purple",
+      "Black",
+      "Navy",
+      "White"
+    ],
+    "sizes": [
+      "XS",
+      "L",
+      "S",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "limited",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-274-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-274-cloudbloc/240/180",
+    "created_at": "2025-05-23",
+    "description": "Designed for comfort and durability, the Wave Tee 96 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1275",
+    "name": "Stratus Bottle 137",
+    "brand": "Northpeak",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 37.6,
+    "rating": 3.6,
+    "reviews": 962,
+    "colors": [
+      "Navy",
+      "Olive"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "2025",
+      "best-seller",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-275-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-275-northpeak/240/180",
+    "created_at": "2024-11-11",
+    "description": "Stratus Bottle 137 from Northpeak is a versatile accessories built for everyday use."
+  },
+  {
+    "id": "sku_1276",
+    "name": "Glide Runner 267",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 176.58,
+    "rating": 3.8,
+    "reviews": 796,
+    "colors": [
+      "Volt",
+      "Gray",
+      "Black"
+    ],
+    "sizes": [
+      "10",
+      "6",
+      "8",
+      "9",
+      "12",
+      "7",
+      "11"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "lightweight",
+      "durable",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-276-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-276-voltline/240/180",
+    "created_at": "2024-10-06",
+    "description": "Designed for comfort and durability, the Glide Runner 267 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1277",
+    "name": "Cumulus Flask 300",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 15.95,
+    "rating": 4.7,
+    "reviews": 18,
+    "colors": [
+      "Blue"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-277-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-277-cloudbloc/240/180",
+    "created_at": "2025-07-12",
+    "description": "Cumulus Flask 300 from Cloudbloc is a versatile accessories built for everyday use."
+  },
+  {
+    "id": "sku_1278",
+    "name": "Cumulus Daily 47",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 145.45,
+    "rating": 4.0,
+    "reviews": 1985,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [
+      "11",
+      "7",
+      "10",
+      "6",
+      "9"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller",
+      "eco",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-278-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-278-voltline/240/180",
+    "created_at": "2025-02-19",
+    "description": "The Cumulus Daily 47 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1279",
+    "name": "Flux Fly 129",
+    "brand": "TrailForge",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 206.83,
+    "rating": 4.2,
+    "reviews": 896,
+    "colors": [
+      "Red",
+      "Tan",
+      "Navy"
+    ],
+    "sizes": [
+      "7",
+      "10",
+      "8",
+      "11",
+      "9",
+      "12",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "lightweight",
+      "new",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-279-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-279-trailforge/240/180",
+    "created_at": "2025-07-13",
+    "description": "Lightweight yet durable, the Flux Fly 129 by TrailForge delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1280",
+    "name": "Urban Tracker 188",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 269.71,
+    "rating": 4.7,
+    "reviews": 1036,
+    "colors": [
+      "Purple",
+      "Gray",
+      "Black",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-280-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-280-nimbusworks/240/180",
+    "created_at": "2025-01-10",
+    "description": "Designed for comfort and durability, the Urban Tracker 188 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1281",
+    "name": "Summit Speaker 255",
+    "brand": "Voltline",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 312.32,
+    "rating": 3.7,
+    "reviews": 579,
+    "colors": [
+      "Forest",
+      "Pink",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "durable",
+      "lightweight",
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-281-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-281-voltline/240/180",
+    "created_at": "2025-06-04",
+    "description": "The Summit Speaker 255 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1282",
+    "name": "Ion Sprint 99",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 102.84,
+    "rating": 4.4,
+    "reviews": 1712,
+    "colors": [
+      "Pink",
+      "Tan",
+      "Red",
+      "Olive"
+    ],
+    "sizes": [
+      "8",
+      "7",
+      "10"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-282-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-282-voltline/240/180",
+    "created_at": "2024-09-16",
+    "description": "The Ion Sprint 99 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1283",
+    "name": "Nimbus Prime 286",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 151.78,
+    "rating": 4.8,
+    "reviews": 1683,
+    "colors": [
+      "Purple",
+      "Black",
+      "Blue"
+    ],
+    "sizes": [
+      "10",
+      "6",
+      "11",
+      "8",
+      "12"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-283-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-283-urbanmesh/240/180",
+    "created_at": "2025-06-02",
+    "description": "The Nimbus Prime 286 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1284",
+    "name": "Echo Shell 99",
+    "brand": "Seoulistic",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 165.24,
+    "rating": 3.9,
+    "reviews": 1280,
+    "colors": [
+      "Red",
+      "Purple"
+    ],
+    "sizes": [
+      "S",
+      "L",
+      "M",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-284-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-284-seoulistic/240/180",
+    "created_at": "2025-04-16",
+    "description": "Lightweight yet durable, the Echo Shell 99 by Seoulistic delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1285",
+    "name": "Echo Crew 337",
+    "brand": "Seoulistic",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 27.81,
+    "rating": 5.0,
+    "reviews": 907,
+    "colors": [
+      "Volt",
+      "Red",
+      "Purple"
+    ],
+    "sizes": [
+      "L",
+      "XXL",
+      "M",
+      "XL",
+      "XS"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "water-resistant",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-285-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-285-seoulistic/240/180",
+    "created_at": "2024-12-28",
+    "description": "Designed for comfort and durability, the Echo Crew 337 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1286",
+    "name": "Aurora Tracker 18",
+    "brand": "TrailForge",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 491.84,
+    "rating": 4.4,
+    "reviews": 1060,
+    "colors": [
+      "Olive",
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-286-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-286-trailforge/240/180",
+    "created_at": "2025-01-01",
+    "description": "Aurora Tracker 18 from TrailForge is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1287",
+    "name": "Summit Pack 49",
+    "brand": "Seoulistic",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 50.09,
+    "rating": 4.0,
+    "reviews": 283,
+    "colors": [
+      "Volt",
+      "Blue",
+      "Navy"
+    ],
+    "sizes": [
+      "20L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-287-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-287-seoulistic/240/180",
+    "created_at": "2025-02-10",
+    "description": "Summit Pack 49 from Seoulistic is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1288",
+    "name": "Neo Jacket 89",
+    "brand": "Northpeak",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 157.66,
+    "rating": 4.8,
+    "reviews": 1439,
+    "colors": [
+      "Blue"
+    ],
+    "sizes": [
+      "S",
+      "L",
+      "M",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "eco",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-288-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-288-northpeak/240/180",
+    "created_at": "2025-02-28",
+    "description": "Lightweight yet durable, the Neo Jacket 89 by Northpeak delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1289",
+    "name": "Aurora Jacket 28",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 120.96,
+    "rating": 3.6,
+    "reviews": 1105,
+    "colors": [
+      "Volt",
+      "Red"
+    ],
+    "sizes": [
+      "M",
+      "S",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "2025",
+      "eco",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-289-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-289-polargrid/240/180",
+    "created_at": "2025-07-11",
+    "description": "PolarGrid's Aurora Jacket 28 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1290",
+    "name": "Stratus Headphones 43",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 205.07,
+    "rating": 4.6,
+    "reviews": 1122,
+    "colors": [
+      "Olive",
+      "White",
+      "Forest",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-290-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-290-zenwave/240/180",
+    "created_at": "2025-09-02",
+    "description": "Zenwave's Stratus Headphones 43 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1291",
+    "name": "Atlas Knife Set 334",
+    "brand": "Voltline",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 89.41,
+    "rating": 4.3,
+    "reviews": 1506,
+    "colors": [
+      "Navy",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-291-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-291-voltline/240/180",
+    "created_at": "2025-04-18",
+    "description": "The Atlas Knife Set 334 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1292",
+    "name": "Flux Headphones 98",
+    "brand": "TrailForge",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 147.67,
+    "rating": 4.4,
+    "reviews": 49,
+    "colors": [
+      "Gray",
+      "Volt",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "eco",
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-292-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-292-trailforge/240/180",
+    "created_at": "2025-04-24",
+    "description": "Designed for comfort and durability, the Flux Headphones 98 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1293",
+    "name": "Stratus Hoodie 58",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 207.92,
+    "rating": 3.9,
+    "reviews": 1271,
+    "colors": [
+      "Olive",
+      "Black"
+    ],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
+    "in_stock": false,
+    "tags": [
+      "eco",
+      "durable",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-293-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-293-auroralab/240/180",
+    "created_at": "2024-12-26",
+    "description": "Designed for comfort and durability, the Stratus Hoodie 58 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1294",
+    "name": "Atlas Pack 356",
+    "brand": "Seoulistic",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 139.33,
+    "rating": 3.5,
+    "reviews": 1193,
+    "colors": [
+      "Olive"
+    ],
+    "sizes": [
+      "20L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "new",
+      "lightweight",
+      "eco",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-294-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-294-seoulistic/240/180",
+    "created_at": "2024-12-21",
+    "description": "Atlas Pack 356 from Seoulistic is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1295",
+    "name": "Urban Prime 443",
+    "brand": "TrailForge",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 81.87,
+    "rating": 3.9,
+    "reviews": 1809,
+    "colors": [
+      "Navy",
+      "Forest",
+      "Red",
+      "White"
+    ],
+    "sizes": [
+      "9",
+      "10",
+      "11",
+      "6",
+      "12"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "2025",
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-295-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-295-trailforge/240/180",
+    "created_at": "2025-05-02",
+    "description": "Lightweight yet durable, the Urban Prime 443 by TrailForge delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1296",
+    "name": "Atlas Commuter 382",
+    "brand": "AuroraLab",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 66.2,
+    "rating": 4.0,
+    "reviews": 720,
+    "colors": [
+      "Pink",
+      "Olive",
+      "Navy"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "2025",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-296-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-296-auroralab/240/180",
+    "created_at": "2025-07-27",
+    "description": "Atlas Commuter 382 from AuroraLab is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1297",
+    "name": "Trail Pan 175",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 134.71,
+    "rating": 4.5,
+    "reviews": 179,
+    "colors": [
+      "Red",
+      "Pink",
+      "Blue",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-297-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-297-nimbusworks/240/180",
+    "created_at": "2025-06-30",
+    "description": "NimbusWorks's Trail Pan 175 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1298",
+    "name": "Glide Stove 106",
+    "brand": "AuroraLab",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 267.29,
+    "rating": 4.4,
+    "reviews": 1400,
+    "colors": [
+      "Gray",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-298-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-298-auroralab/240/180",
+    "created_at": "2025-06-05",
+    "description": "Glide Stove 106 from AuroraLab is a versatile outdoors built for everyday use."
+  },
+  {
+    "id": "sku_1299",
+    "name": "Cumulus Crew 35",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 52.56,
+    "rating": 4.9,
+    "reviews": 242,
+    "colors": [
+      "Volt",
+      "Gray"
+    ],
+    "sizes": [
+      "M",
+      "L",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "durable",
+      "best-seller",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-299-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-299-polargrid/240/180",
+    "created_at": "2025-08-02",
+    "description": "Cumulus Crew 35 from PolarGrid is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1300",
+    "name": "Aurora Crew 311 · 한정판",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 53.16,
+    "rating": 3.8,
+    "reviews": 475,
+    "colors": [
+      "블랙",
+      "네이비",
+      "Black",
+      "Pink"
+    ],
+    "sizes": [
+      "XS",
+      "L",
+      "S",
+      "M",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-300-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-300-zenwave/240/180",
+    "created_at": "2025-03-20",
+    "description": "The Aurora Crew 311 · 한정판 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1301",
+    "name": "Cumulus Watch 116",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 92.54,
+    "rating": 4.6,
+    "reviews": 30,
+    "colors": [
+      "Forest",
+      "Navy",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-301-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-301-zenwave/240/180",
+    "created_at": "2024-10-13",
+    "description": "Designed for comfort and durability, the Cumulus Watch 116 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1302",
+    "name": "Neo Chair 455",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 113.53,
+    "rating": 4.1,
+    "reviews": 85,
+    "colors": [
+      "Purple",
+      "Volt",
+      "Forest",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-302-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-302-urbanmesh/240/180",
+    "created_at": "2025-09-05",
+    "description": "Neo Chair 455 from UrbanMesh is a versatile outdoors built for everyday use."
+  },
+  {
+    "id": "sku_1303",
+    "name": "Trail Tracker 276",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 245.16,
+    "rating": 4.6,
+    "reviews": 1142,
+    "colors": [
+      "Red",
+      "Pink",
+      "Black",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-303-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-303-cloudbloc/240/180",
+    "created_at": "2025-04-01",
+    "description": "Cloudbloc's Trail Tracker 276 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1304",
+    "name": "Tempo Earbuds 354",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 220.28,
+    "rating": 3.7,
+    "reviews": 1699,
+    "colors": [
+      "White",
+      "Red",
+      "Purple",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "eco",
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-304-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-304-nimbusworks/240/180",
+    "created_at": "2025-09-01",
+    "description": "NimbusWorks's Tempo Earbuds 354 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1305",
+    "name": "Cumulus Band 303",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 455.58,
+    "rating": 4.8,
+    "reviews": 1807,
+    "colors": [
+      "White",
+      "Olive",
+      "Volt",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-305-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-305-cloudbloc/240/180",
+    "created_at": "2024-11-12",
+    "description": "Lightweight yet durable, the Cumulus Band 303 by Cloudbloc delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1306",
+    "name": "Volt Tracker 363",
+    "brand": "AuroraLab",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 240.32,
+    "rating": 4.7,
+    "reviews": 1047,
+    "colors": [
+      "Forest",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "durable",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-306-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-306-auroralab/240/180",
+    "created_at": "2024-12-06",
+    "description": "The Volt Tracker 363 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1307",
+    "name": "Pulse Crew 159",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 63.27,
+    "rating": 4.9,
+    "reviews": 591,
+    "colors": [
+      "White",
+      "Gray"
+    ],
+    "sizes": [
+      "XS",
+      "XL",
+      "M",
+      "XXL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new",
+      "eco",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-307-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-307-cloudbloc/240/180",
+    "created_at": "2025-05-23",
+    "description": "Pulse Crew 159 from Cloudbloc is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1308",
+    "name": "Atlas Jacket 210",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 148.38,
+    "rating": 4.4,
+    "reviews": 13,
+    "colors": [
+      "Red",
+      "Olive"
+    ],
+    "sizes": [
+      "S",
+      "XL",
+      "L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-308-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-308-polargrid/240/180",
+    "created_at": "2025-03-07",
+    "description": "Lightweight yet durable, the Atlas Jacket 210 by PolarGrid delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1309",
+    "name": "Tempo Stride 170",
+    "brand": "PolarGrid",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 209.65,
+    "rating": 3.6,
+    "reviews": 853,
+    "colors": [
+      "Gray",
+      "Pink"
+    ],
+    "sizes": [
+      "10",
+      "11",
+      "12",
+      "7",
+      "9"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-309-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-309-polargrid/240/180",
+    "created_at": "2025-03-13",
+    "description": "Designed for comfort and durability, the Tempo Stride 170 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1310",
+    "name": "Flux Commuter 420",
+    "brand": "AuroraLab",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 54.14,
+    "rating": 4.1,
+    "reviews": 1127,
+    "colors": [
+      "Olive"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "new",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-310-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-310-auroralab/240/180",
+    "created_at": "2025-08-31",
+    "description": "Flux Commuter 420 from AuroraLab is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1311",
+    "name": "Zen Kettle 56",
+    "brand": "Voltline",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 89.42,
+    "rating": 5.0,
+    "reviews": 1083,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco",
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-311-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-311-voltline/240/180",
+    "created_at": "2025-07-16",
+    "description": "Zen Kettle 56 from Voltline is a versatile home built for everyday use."
+  },
+  {
+    "id": "sku_1312",
+    "name": "Aero Carry 475",
+    "brand": "Seoulistic",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 62.51,
+    "rating": 4.3,
+    "reviews": 1064,
+    "colors": [
+      "Tan",
+      "Gray",
+      "Blue",
+      "Navy"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-312-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-312-seoulistic/240/180",
+    "created_at": "2024-09-10",
+    "description": "Aero Carry 475 from Seoulistic is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1313",
+    "name": "Tempo Daily 212",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 75.0,
+    "rating": 4.0,
+    "reviews": 1650,
+    "colors": [
+      "Black",
+      "Pink"
+    ],
+    "sizes": [
+      "11",
+      "8",
+      "12",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller",
+      "lightweight",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-313-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-313-voltline/240/180",
+    "created_at": "2025-05-27",
+    "description": "Lightweight yet durable, the Tempo Daily 212 by Voltline delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1314",
+    "name": "Echo Bottle 427",
+    "brand": "AuroraLab",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 17.8,
+    "rating": 4.0,
+    "reviews": 692,
+    "colors": [
+      "Tan",
+      "Black",
+      "Gray",
+      "Purple"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "best-seller",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-314-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-314-auroralab/240/180",
+    "created_at": "2025-06-11",
+    "description": "The Echo Bottle 427 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1315",
+    "name": "Polar Racer 372",
+    "brand": "Seoulistic",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 178.17,
+    "rating": 4.3,
+    "reviews": 38,
+    "colors": [
+      "Blue",
+      "Pink"
+    ],
+    "sizes": [
+      "12",
+      "8",
+      "6",
+      "7",
+      "9"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "new",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-315-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-315-seoulistic/240/180",
+    "created_at": "2025-03-02",
+    "description": "Designed for comfort and durability, the Polar Racer 372 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1316",
+    "name": "Tempo Earbuds 443",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 318.47,
+    "rating": 4.0,
+    "reviews": 1756,
+    "colors": [
+      "Purple",
+      "Black",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-316-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-316-zenwave/240/180",
+    "created_at": "2025-05-22",
+    "description": "The Tempo Earbuds 443 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1317",
+    "name": "Summit Carry 90",
+    "brand": "Voltline",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 60.15,
+    "rating": 4.7,
+    "reviews": 1592,
+    "colors": [
+      "White",
+      "Tan"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-317-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-317-voltline/240/180",
+    "created_at": "2025-05-24",
+    "description": "Designed for comfort and durability, the Summit Carry 90 is perfect for bags needs."
+  },
+  {
+    "id": "sku_1318",
+    "name": "Polar Band 74",
+    "brand": "Seoulistic",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 402.18,
+    "rating": 3.6,
+    "reviews": 1921,
+    "colors": [
+      "Navy",
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "lightweight",
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-318-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-318-seoulistic/240/180",
+    "created_at": "2025-09-10",
+    "description": "Seoulistic's Polar Band 74 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1319",
+    "name": "Neo Chair 456",
+    "brand": "Northpeak",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 37.49,
+    "rating": 4.3,
+    "reviews": 1349,
+    "colors": [
+      "Black",
+      "Blue",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "durable",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-319-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-319-northpeak/240/180",
+    "created_at": "2024-12-26",
+    "description": "The Neo Chair 456 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1320",
+    "name": "Neo Commuter 344",
+    "brand": "Seoulistic",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 60.88,
+    "rating": 3.7,
+    "reviews": 560,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "water-resistant",
+      "durable",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-320-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-320-seoulistic/240/180",
+    "created_at": "2025-03-08",
+    "description": "Lightweight yet durable, the Neo Commuter 344 by Seoulistic delivers outstanding quality for bags enthusiasts."
+  },
+  {
+    "id": "sku_1321",
+    "name": "Cumulus Tent 160",
+    "brand": "Voltline",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 252.43,
+    "rating": 4.0,
+    "reviews": 908,
+    "colors": [
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "durable",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-321-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-321-voltline/240/180",
+    "created_at": "2025-08-21",
+    "description": "Voltline's Cumulus Tent 160 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1322",
+    "name": "Pulse Sprint 92",
+    "brand": "Northpeak",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 181.61,
+    "rating": 4.8,
+    "reviews": 1289,
+    "colors": [
+      "Blue",
+      "Volt",
+      "Olive",
+      "Pink"
+    ],
+    "sizes": [
+      "11",
+      "12",
+      "10",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "lightweight",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-322-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-322-northpeak/240/180",
+    "created_at": "2025-05-06",
+    "description": "The Pulse Sprint 92 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1323",
+    "name": "Polar Daily 241",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 95.49,
+    "rating": 3.8,
+    "reviews": 1763,
+    "colors": [
+      "Volt",
+      "Forest",
+      "Gray"
+    ],
+    "sizes": [
+      "12",
+      "8",
+      "9",
+      "10",
+      "6"
+    ],
+    "in_stock": false,
+    "tags": [
+      "2025",
+      "eco",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-323-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-323-urbanmesh/240/180",
+    "created_at": "2024-11-06",
+    "description": "The Polar Daily 241 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1324",
+    "name": "Tempo Pack 261",
+    "brand": "AuroraLab",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 58.9,
+    "rating": 4.7,
+    "reviews": 1631,
+    "colors": [
+      "Volt"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "new",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-324-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-324-auroralab/240/180",
+    "created_at": "2025-06-09",
+    "description": "The Tempo Pack 261 combines modern style with reliable performance in bags gear."
+  },
+  {
+    "id": "sku_1325",
+    "name": "Trail Anorak 82",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 254.78,
+    "rating": 4.1,
+    "reviews": 697,
+    "colors": [
+      "Purple",
+      "Blue"
+    ],
+    "sizes": [
+      "XL",
+      "L",
+      "M",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-325-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-325-polargrid/240/180",
+    "created_at": "2025-08-18",
+    "description": "PolarGrid's Trail Anorak 82 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1326",
+    "name": "Glide Lantern 285",
+    "brand": "PolarGrid",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 57.01,
+    "rating": 4.2,
+    "reviews": 630,
+    "colors": [
+      "White",
+      "Blue",
+      "Purple",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "2025",
+      "durable",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-326-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-326-polargrid/240/180",
+    "created_at": "2025-08-06",
+    "description": "Glide Lantern 285 from PolarGrid is a versatile outdoors built for everyday use."
+  },
+  {
+    "id": "sku_1327",
+    "name": "Stratus Stove 232",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 221.35,
+    "rating": 4.1,
+    "reviews": 1183,
+    "colors": [
+      "Navy",
+      "Purple",
+      "Volt",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "limited",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-327-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-327-cloudbloc/240/180",
+    "created_at": "2025-08-23",
+    "description": "Lightweight yet durable, the Stratus Stove 232 by Cloudbloc delivers outstanding quality for outdoors enthusiasts."
+  },
+  {
+    "id": "sku_1328",
+    "name": "Aurora Daily 434",
+    "brand": "PolarGrid",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 84.03,
+    "rating": 3.9,
+    "reviews": 756,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [
+      "12",
+      "8",
+      "6",
+      "11",
+      "10",
+      "9",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "2025",
+      "eco",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-328-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-328-polargrid/240/180",
+    "created_at": "2025-03-30",
+    "description": "Lightweight yet durable, the Aurora Daily 434 by PolarGrid delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1329",
+    "name": "Wave Earbuds 340",
+    "brand": "TrailForge",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 93.16,
+    "rating": 3.7,
+    "reviews": 1137,
+    "colors": [
+      "Volt",
+      "Forest",
+      "Gray",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-329-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-329-trailforge/240/180",
+    "created_at": "2025-08-19",
+    "description": "Wave Earbuds 340 from TrailForge is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1330",
+    "name": "Stratus Daily 337",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 118.04,
+    "rating": 5.0,
+    "reviews": 173,
+    "colors": [
+      "Pink",
+      "Forest"
+    ],
+    "sizes": [
+      "12",
+      "11",
+      "10",
+      "9",
+      "8",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "eco",
+      "water-resistant",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-330-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-330-cloudbloc/240/180",
+    "created_at": "2025-04-15",
+    "description": "Designed for comfort and durability, the Stratus Daily 337 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1331",
+    "name": "Tempo Tee 296",
+    "brand": "TrailForge",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 48.89,
+    "rating": 4.6,
+    "reviews": 1458,
+    "colors": [
+      "Forest",
+      "Red",
+      "Blue"
+    ],
+    "sizes": [
+      "XS",
+      "XXL",
+      "L",
+      "M",
+      "S"
+    ],
+    "in_stock": false,
+    "tags": [
+      "durable",
+      "2025",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-331-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-331-trailforge/240/180",
+    "created_at": "2025-05-14",
+    "description": "TrailForge's Tempo Tee 296 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1332",
+    "name": "Summit Daypack 268",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 165.14,
+    "rating": 3.6,
+    "reviews": 967,
+    "colors": [
+      "Pink"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "eco",
+      "best-seller",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-332-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-332-urbanmesh/240/180",
+    "created_at": "2025-03-04",
+    "description": "Summit Daypack 268 from UrbanMesh is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1333",
+    "name": "Neo Band 181",
+    "brand": "PolarGrid",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 482.44,
+    "rating": 4.7,
+    "reviews": 592,
+    "colors": [
+      "Black",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-333-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-333-polargrid/240/180",
+    "created_at": "2025-06-25",
+    "description": "Designed for comfort and durability, the Neo Band 181 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1334",
+    "name": "Aero Tent 337",
+    "brand": "Zenwave",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 395.35,
+    "rating": 4.7,
+    "reviews": 1278,
+    "colors": [
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "best-seller",
+      "water-resistant",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-334-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-334-zenwave/240/180",
+    "created_at": "2024-11-13",
+    "description": "Zenwave's Aero Tent 337 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1335",
+    "name": "Urban Crew 440",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 33.93,
+    "rating": 4.6,
+    "reviews": 1236,
+    "colors": [
+      "Blue",
+      "Gray"
+    ],
+    "sizes": [
+      "M",
+      "S",
+      "XXL",
+      "L",
+      "XS",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-335-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-335-polargrid/240/180",
+    "created_at": "2025-06-07",
+    "description": "The Urban Crew 440 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1336",
+    "name": "Stratus Performance Tee 386",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 79.6,
+    "rating": 4.7,
+    "reviews": 487,
+    "colors": [
+      "Purple",
+      "Pink",
+      "Gray",
+      "Navy"
+    ],
+    "sizes": [
+      "XS",
+      "M",
+      "XXL",
+      "L",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-336-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-336-polargrid/240/180",
+    "created_at": "2025-05-11",
+    "description": "Designed for comfort and durability, the Stratus Performance Tee 386 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1337",
+    "name": "Echo Jacket 135",
+    "brand": "TrailForge",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 89.03,
+    "rating": 4.8,
+    "reviews": 24,
+    "colors": [
+      "Tan",
+      "Forest",
+      "Volt"
+    ],
+    "sizes": [
+      "S",
+      "L",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "water-resistant",
+      "best-seller",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-337-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-337-trailforge/240/180",
+    "created_at": "2025-04-19",
+    "description": "The Echo Jacket 135 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1338",
+    "name": "Aero Daily 237",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 155.05,
+    "rating": 4.6,
+    "reviews": 1503,
+    "colors": [
+      "Red",
+      "Volt"
+    ],
+    "sizes": [
+      "8",
+      "10",
+      "6",
+      "11"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "new",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-338-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-338-nimbusworks/240/180",
+    "created_at": "2024-09-16",
+    "description": "Lightweight yet durable, the Aero Daily 237 by NimbusWorks delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1339",
+    "name": "Trail Tracker 146",
+    "brand": "AuroraLab",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 184.8,
+    "rating": 3.6,
+    "reviews": 1268,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-339-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-339-auroralab/240/180",
+    "created_at": "2025-08-12",
+    "description": "AuroraLab's Trail Tracker 146 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1340",
+    "name": "Tempo Street 193",
+    "brand": "Northpeak",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 142.2,
+    "rating": 4.8,
+    "reviews": 1159,
+    "colors": [
+      "White",
+      "Gray"
+    ],
+    "sizes": [
+      "8",
+      "9",
+      "6",
+      "11",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "water-resistant",
+      "durable",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-340-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-340-northpeak/240/180",
+    "created_at": "2025-08-30",
+    "description": "Lightweight yet durable, the Tempo Street 193 by Northpeak delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1341",
+    "name": "Echo Commuter 171",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 179.45,
+    "rating": 3.9,
+    "reviews": 1664,
+    "colors": [
+      "Gray",
+      "Tan",
+      "White"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "durable",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-341-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-341-cloudbloc/240/180",
+    "created_at": "2024-12-21",
+    "description": "Lightweight yet durable, the Echo Commuter 171 by Cloudbloc delivers outstanding quality for bags enthusiasts."
+  },
+  {
+    "id": "sku_1342",
+    "name": "Wave Daily 112",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 137.54,
+    "rating": 3.7,
+    "reviews": 904,
+    "colors": [
+      "White",
+      "Black",
+      "Purple"
+    ],
+    "sizes": [
+      "10",
+      "11",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "limited",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-342-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-342-zenwave/240/180",
+    "created_at": "2024-09-19",
+    "description": "The Wave Daily 112 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1343",
+    "name": "Echo Stride 78",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 181.01,
+    "rating": 4.9,
+    "reviews": 1176,
+    "colors": [
+      "Red"
+    ],
+    "sizes": [
+      "9",
+      "12",
+      "11",
+      "6",
+      "8",
+      "10"
+    ],
+    "in_stock": false,
+    "tags": [
+      "durable",
+      "new",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-343-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-343-cloudbloc/240/180",
+    "created_at": "2025-08-28",
+    "description": "Echo Stride 78 from Cloudbloc is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1344",
+    "name": "Polar Flask 29",
+    "brand": "AuroraLab",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 32.86,
+    "rating": 4.9,
+    "reviews": 185,
+    "colors": [
+      "Red",
+      "Volt",
+      "White"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "durable",
+      "new",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-344-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-344-auroralab/240/180",
+    "created_at": "2025-02-05",
+    "description": "Designed for comfort and durability, the Polar Flask 29 is perfect for accessories needs."
+  },
+  {
+    "id": "sku_1345",
+    "name": "Polar Speaker 200",
+    "brand": "Voltline",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 360.69,
+    "rating": 4.4,
+    "reviews": 735,
+    "colors": [
+      "White",
+      "Pink",
+      "Tan",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-345-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-345-voltline/240/180",
+    "created_at": "2024-12-17",
+    "description": "The Polar Speaker 200 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1346",
+    "name": "Wave Speaker 158",
+    "brand": "Northpeak",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 213.88,
+    "rating": 4.9,
+    "reviews": 1662,
+    "colors": [
+      "Black",
+      "Purple",
+      "Volt",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-346-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-346-northpeak/240/180",
+    "created_at": "2024-10-01",
+    "description": "The Wave Speaker 158 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1347",
+    "name": "Wave Pan 380",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 90.53,
+    "rating": 4.9,
+    "reviews": 75,
+    "colors": [
+      "Tan",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-347-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-347-urbanmesh/240/180",
+    "created_at": "2025-07-23",
+    "description": "Designed for comfort and durability, the Wave Pan 380 is perfect for home needs."
+  },
+  {
+    "id": "sku_1348",
+    "name": "Cumulus Tee 464",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 37.05,
+    "rating": 4.7,
+    "reviews": 934,
+    "colors": [
+      "Blue",
+      "White"
+    ],
+    "sizes": [
+      "XS",
+      "L",
+      "S"
+    ],
+    "in_stock": false,
+    "tags": [
+      "limited",
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-348-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-348-cloudbloc/240/180",
+    "created_at": "2024-12-22",
+    "description": "The Cumulus Tee 464 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1349",
+    "name": "Ion Speaker 295",
+    "brand": "AuroraLab",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 230.98,
+    "rating": 4.0,
+    "reviews": 1975,
+    "colors": [
+      "Black",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-349-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-349-auroralab/240/180",
+    "created_at": "2024-10-12",
+    "description": "The Ion Speaker 295 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1350",
+    "name": "Flux Speaker 85 · 한정판",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 191.3,
+    "rating": 4.9,
+    "reviews": 83,
+    "colors": [
+      "블랙",
+      "네이비",
+      "White",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-350-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-350-zenwave/240/180",
+    "created_at": "2024-11-29",
+    "description": "The Flux Speaker 85 · 한정판 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1351",
+    "name": "Cumulus Runner 362",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 174.73,
+    "rating": 4.8,
+    "reviews": 852,
+    "colors": [
+      "Purple",
+      "Gray",
+      "Navy",
+      "Pink"
+    ],
+    "sizes": [
+      "10",
+      "9",
+      "11",
+      "7",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "limited",
+      "eco",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-351-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-351-cloudbloc/240/180",
+    "created_at": "2024-09-29",
+    "description": "Lightweight yet durable, the Cumulus Runner 362 by Cloudbloc delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1352",
+    "name": "Flux Daily 3",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 131.35,
+    "rating": 3.8,
+    "reviews": 1085,
+    "colors": [
+      "Blue"
+    ],
+    "sizes": [
+      "12",
+      "10",
+      "11",
+      "7",
+      "9"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-352-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-352-nimbusworks/240/180",
+    "created_at": "2025-08-13",
+    "description": "The Flux Daily 3 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1353",
+    "name": "Stratus Jacket 255",
+    "brand": "Northpeak",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 95.26,
+    "rating": 4.5,
+    "reviews": 88,
+    "colors": [
+      "Pink"
+    ],
+    "sizes": [
+      "L",
+      "S",
+      "M",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-353-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-353-northpeak/240/180",
+    "created_at": "2025-04-30",
+    "description": "The Stratus Jacket 255 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1354",
+    "name": "Cumulus Fly 403",
+    "brand": "Seoulistic",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 93.78,
+    "rating": 4.3,
+    "reviews": 145,
+    "colors": [
+      "Purple",
+      "Tan"
+    ],
+    "sizes": [
+      "10",
+      "8",
+      "9",
+      "7",
+      "11",
+      "12",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-354-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-354-seoulistic/240/180",
+    "created_at": "2025-02-23",
+    "description": "Designed for comfort and durability, the Cumulus Fly 403 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1355",
+    "name": "Echo Earbuds 38",
+    "brand": "Voltline",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 203.27,
+    "rating": 4.2,
+    "reviews": 1823,
+    "colors": [
+      "Gray",
+      "Navy",
+      "Blue",
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-355-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-355-voltline/240/180",
+    "created_at": "2025-03-20",
+    "description": "The Echo Earbuds 38 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1356",
+    "name": "Urban Shell 172",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 85.44,
+    "rating": 4.5,
+    "reviews": 122,
+    "colors": [
+      "Gray",
+      "White",
+      "Tan"
+    ],
+    "sizes": [
+      "XL",
+      "S",
+      "M",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-356-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-356-auroralab/240/180",
+    "created_at": "2025-07-16",
+    "description": "Lightweight yet durable, the Urban Shell 172 by AuroraLab delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1357",
+    "name": "Volt Knife Set 439",
+    "brand": "Voltline",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 82.53,
+    "rating": 4.8,
+    "reviews": 443,
+    "colors": [
+      "Tan",
+      "Olive",
+      "Black",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-357-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-357-voltline/240/180",
+    "created_at": "2025-01-14",
+    "description": "Lightweight yet durable, the Volt Knife Set 439 by Voltline delivers outstanding quality for home enthusiasts."
+  },
+  {
+    "id": "sku_1358",
+    "name": "Aero Stove 468",
+    "brand": "Voltline",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 237.43,
+    "rating": 3.5,
+    "reviews": 90,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-358-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-358-voltline/240/180",
+    "created_at": "2025-05-26",
+    "description": "Designed for comfort and durability, the Aero Stove 468 is perfect for outdoors needs."
+  },
+  {
+    "id": "sku_1359",
+    "name": "Ion Headphones 254",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 117.99,
+    "rating": 4.3,
+    "reviews": 25,
+    "colors": [
+      "Navy",
+      "Gray",
+      "Volt",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-359-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-359-urbanmesh/240/180",
+    "created_at": "2024-10-26",
+    "description": "UrbanMesh's Ion Headphones 254 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1360",
+    "name": "Glide Daypack 500",
+    "brand": "Zenwave",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 106.4,
+    "rating": 4.7,
+    "reviews": 1790,
+    "colors": [
+      "Gray",
+      "Volt",
+      "Tan",
+      "Black"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "water-resistant",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-360-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-360-zenwave/240/180",
+    "created_at": "2025-08-29",
+    "description": "Designed for comfort and durability, the Glide Daypack 500 is perfect for bags needs."
+  },
+  {
+    "id": "sku_1361",
+    "name": "Wave Pack 404",
+    "brand": "PolarGrid",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 137.43,
+    "rating": 4.4,
+    "reviews": 687,
+    "colors": [
+      "Red"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "eco",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-361-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-361-polargrid/240/180",
+    "created_at": "2024-11-05",
+    "description": "PolarGrid's Wave Pack 404 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1362",
+    "name": "Flux Fly 332",
+    "brand": "AuroraLab",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 162.64,
+    "rating": 3.6,
+    "reviews": 1452,
+    "colors": [
+      "Gray",
+      "Volt"
+    ],
+    "sizes": [
+      "10",
+      "6",
+      "9",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "water-resistant",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-362-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-362-auroralab/240/180",
+    "created_at": "2025-01-03",
+    "description": "Flux Fly 332 from AuroraLab is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1363",
+    "name": "Nimbus Earbuds 191",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 156.73,
+    "rating": 4.2,
+    "reviews": 1078,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco",
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-363-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-363-nimbusworks/240/180",
+    "created_at": "2025-08-23",
+    "description": "Nimbus Earbuds 191 from NimbusWorks is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1364",
+    "name": "Glide Classic 42",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 112.98,
+    "rating": 3.8,
+    "reviews": 1962,
+    "colors": [
+      "White"
+    ],
+    "sizes": [
+      "8",
+      "6",
+      "7",
+      "9"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "water-resistant",
+      "eco",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-364-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-364-voltline/240/180",
+    "created_at": "2024-12-23",
+    "description": "Glide Classic 42 from Voltline is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1365",
+    "name": "Flux Performance Tee 228",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 63.74,
+    "rating": 3.5,
+    "reviews": 387,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [
+      "XL",
+      "M",
+      "L",
+      "XXL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-365-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-365-urbanmesh/240/180",
+    "created_at": "2025-08-06",
+    "description": "Designed for comfort and durability, the Flux Performance Tee 228 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1366",
+    "name": "Glide Knife Set 156",
+    "brand": "Seoulistic",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 88.85,
+    "rating": 4.8,
+    "reviews": 627,
+    "colors": [
+      "Olive",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-366-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-366-seoulistic/240/180",
+    "created_at": "2025-02-04",
+    "description": "Lightweight yet durable, the Glide Knife Set 156 by Seoulistic delivers outstanding quality for home enthusiasts."
+  },
+  {
+    "id": "sku_1367",
+    "name": "Cumulus Pack 365",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 117.27,
+    "rating": 3.8,
+    "reviews": 359,
+    "colors": [
+      "Gray",
+      "Navy"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "water-resistant",
+      "eco",
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-367-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-367-urbanmesh/240/180",
+    "created_at": "2025-02-19",
+    "description": "Designed for comfort and durability, the Cumulus Pack 365 is perfect for bags needs."
+  },
+  {
+    "id": "sku_1368",
+    "name": "Wave Tee 341",
+    "brand": "Voltline",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 37.65,
+    "rating": 4.0,
+    "reviews": 763,
+    "colors": [
+      "Red",
+      "Gray",
+      "Purple",
+      "Olive"
+    ],
+    "sizes": [
+      "XS",
+      "L",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-368-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-368-voltline/240/180",
+    "created_at": "2025-05-02",
+    "description": "Lightweight yet durable, the Wave Tee 341 by Voltline delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1369",
+    "name": "Neo Mug 243",
+    "brand": "Seoulistic",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 134.54,
+    "rating": 5.0,
+    "reviews": 1544,
+    "colors": [
+      "Blue",
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight",
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-369-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-369-seoulistic/240/180",
+    "created_at": "2024-11-06",
+    "description": "Seoulistic's Neo Mug 243 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1370",
+    "name": "Aurora Daily 317",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 162.5,
+    "rating": 4.2,
+    "reviews": 189,
+    "colors": [
+      "Black",
+      "Blue",
+      "Navy"
+    ],
+    "sizes": [
+      "10",
+      "7",
+      "8",
+      "11",
+      "6",
+      "12",
+      "9"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "durable",
+      "eco",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-370-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-370-nimbusworks/240/180",
+    "created_at": "2024-10-24",
+    "description": "Aurora Daily 317 from NimbusWorks is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1371",
+    "name": "Summit Tent 466",
+    "brand": "PolarGrid",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 272.7,
+    "rating": 4.1,
+    "reviews": 1466,
+    "colors": [
+      "Volt",
+      "Forest",
+      "Purple",
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "best-seller",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-371-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-371-polargrid/240/180",
+    "created_at": "2025-03-08",
+    "description": "The Summit Tent 466 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1372",
+    "name": "Glide Daily 412",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 118.68,
+    "rating": 3.7,
+    "reviews": 1490,
+    "colors": [
+      "Purple",
+      "Forest",
+      "Gray",
+      "White"
+    ],
+    "sizes": [
+      "7",
+      "8",
+      "9",
+      "11"
+    ],
+    "in_stock": false,
+    "tags": [
+      "durable",
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-372-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-372-voltline/240/180",
+    "created_at": "2025-07-09",
+    "description": "Glide Daily 412 from Voltline is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1373",
+    "name": "Cumulus Commuter 364",
+    "brand": "TrailForge",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 121.67,
+    "rating": 4.9,
+    "reviews": 408,
+    "colors": [
+      "Forest",
+      "Olive"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "new",
+      "eco",
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-373-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-373-trailforge/240/180",
+    "created_at": "2025-02-11",
+    "description": "TrailForge's Cumulus Commuter 364 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1374",
+    "name": "Aurora Shell 135",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 120.03,
+    "rating": 4.5,
+    "reviews": 1303,
+    "colors": [
+      "White",
+      "Pink",
+      "Olive",
+      "Forest"
+    ],
+    "sizes": [
+      "XL",
+      "L",
+      "S"
+    ],
+    "in_stock": false,
+    "tags": [
+      "durable",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-374-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-374-cloudbloc/240/180",
+    "created_at": "2025-01-29",
+    "description": "Designed for comfort and durability, the Aurora Shell 135 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1375",
+    "name": "Atlas Flask 445",
+    "brand": "PolarGrid",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 20.51,
+    "rating": 4.5,
+    "reviews": 1995,
+    "colors": [
+      "Volt"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "new",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-375-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-375-polargrid/240/180",
+    "created_at": "2024-09-18",
+    "description": "Lightweight yet durable, the Atlas Flask 445 by PolarGrid delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1376",
+    "name": "Glide Tech Tee 183",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 28.13,
+    "rating": 3.9,
+    "reviews": 859,
+    "colors": [
+      "Black",
+      "Olive",
+      "Pink"
+    ],
+    "sizes": [
+      "XL",
+      "S",
+      "XXL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-376-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-376-auroralab/240/180",
+    "created_at": "2025-07-13",
+    "description": "The Glide Tech Tee 183 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1377",
+    "name": "Urban Flask 50",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 29.64,
+    "rating": 4.0,
+    "reviews": 294,
+    "colors": [
+      "Gray"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "durable",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-377-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-377-nimbusworks/240/180",
+    "created_at": "2025-05-16",
+    "description": "NimbusWorks's Urban Flask 50 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1378",
+    "name": "Summit Shell 426",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 97.68,
+    "rating": 4.8,
+    "reviews": 1256,
+    "colors": [
+      "Forest"
+    ],
+    "sizes": [
+      "S",
+      "XL",
+      "L",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "durable",
+      "eco",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-378-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-378-zenwave/240/180",
+    "created_at": "2025-02-16",
+    "description": "Designed for comfort and durability, the Summit Shell 426 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1379",
+    "name": "Cumulus Mug 15",
+    "brand": "AuroraLab",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 113.48,
+    "rating": 3.7,
+    "reviews": 263,
+    "colors": [
+      "Purple",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-379-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-379-auroralab/240/180",
+    "created_at": "2024-12-26",
+    "description": "Designed for comfort and durability, the Cumulus Mug 15 is perfect for home needs."
+  },
+  {
+    "id": "sku_1380",
+    "name": "Aurora Daily 388",
+    "brand": "Northpeak",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 117.44,
+    "rating": 3.8,
+    "reviews": 67,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [
+      "8",
+      "6",
+      "11"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-380-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-380-northpeak/240/180",
+    "created_at": "2024-09-15",
+    "description": "Northpeak's Aurora Daily 388 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1381",
+    "name": "Zen Shell 344",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 130.31,
+    "rating": 3.6,
+    "reviews": 1732,
+    "colors": [
+      "Blue",
+      "Volt",
+      "Pink"
+    ],
+    "sizes": [
+      "M",
+      "L",
+      "S"
+    ],
+    "in_stock": false,
+    "tags": [
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-381-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-381-polargrid/240/180",
+    "created_at": "2025-07-03",
+    "description": "PolarGrid's Zen Shell 344 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1382",
+    "name": "Cumulus Anorak 3",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 254.72,
+    "rating": 3.6,
+    "reviews": 438,
+    "colors": [
+      "Volt",
+      "Blue",
+      "Gray",
+      "Tan"
+    ],
+    "sizes": [
+      "M",
+      "XL",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-382-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-382-nimbusworks/240/180",
+    "created_at": "2025-05-31",
+    "description": "Lightweight yet durable, the Cumulus Anorak 3 by NimbusWorks delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1383",
+    "name": "Glide Bottle 267",
+    "brand": "Northpeak",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 16.49,
+    "rating": 4.6,
+    "reviews": 1443,
+    "colors": [
+      "Red",
+      "Black",
+      "White"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-383-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-383-northpeak/240/180",
+    "created_at": "2025-03-26",
+    "description": "Lightweight yet durable, the Glide Bottle 267 by Northpeak delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1384",
+    "name": "Trail Commuter 149",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 177.97,
+    "rating": 4.1,
+    "reviews": 1754,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "eco",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-384-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-384-urbanmesh/240/180",
+    "created_at": "2025-08-21",
+    "description": "UrbanMesh's Trail Commuter 149 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1385",
+    "name": "Ion Pan 203",
+    "brand": "Northpeak",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 65.69,
+    "rating": 4.4,
+    "reviews": 208,
+    "colors": [
+      "White",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-385-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-385-northpeak/240/180",
+    "created_at": "2025-03-02",
+    "description": "Lightweight yet durable, the Ion Pan 203 by Northpeak delivers outstanding quality for home enthusiasts."
+  },
+  {
+    "id": "sku_1386",
+    "name": "Atlas Puffer 392",
+    "brand": "TrailForge",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 202.7,
+    "rating": 4.4,
+    "reviews": 559,
+    "colors": [
+      "Volt",
+      "Tan",
+      "Blue",
+      "Forest"
+    ],
+    "sizes": [
+      "L",
+      "S",
+      "M",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "limited",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-386-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-386-trailforge/240/180",
+    "created_at": "2025-05-18",
+    "description": "The Atlas Puffer 392 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1387",
+    "name": "Nimbus Runner 256",
+    "brand": "Northpeak",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 178.15,
+    "rating": 5.0,
+    "reviews": 783,
+    "colors": [
+      "Gray",
+      "Olive",
+      "Blue"
+    ],
+    "sizes": [
+      "6",
+      "12",
+      "10",
+      "9",
+      "7",
+      "11",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "2025",
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-387-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-387-northpeak/240/180",
+    "created_at": "2025-05-19",
+    "description": "Nimbus Runner 256 from Northpeak is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1388",
+    "name": "Nimbus Knife Set 451",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 137.18,
+    "rating": 4.1,
+    "reviews": 644,
+    "colors": [
+      "Tan",
+      "Purple",
+      "Black",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "eco",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-388-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-388-cloudbloc/240/180",
+    "created_at": "2025-08-13",
+    "description": "Designed for comfort and durability, the Nimbus Knife Set 451 is perfect for home needs."
+  },
+  {
+    "id": "sku_1389",
+    "name": "Echo Performance Tee 392",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 24.78,
+    "rating": 4.5,
+    "reviews": 1351,
+    "colors": [
+      "Tan",
+      "Red",
+      "Gray",
+      "Pink"
+    ],
+    "sizes": [
+      "L",
+      "M",
+      "XXL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller",
+      "water-resistant",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-389-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-389-nimbusworks/240/180",
+    "created_at": "2025-03-22",
+    "description": "NimbusWorks's Echo Performance Tee 392 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1390",
+    "name": "Aero Runner 66",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 198.8,
+    "rating": 4.0,
+    "reviews": 1519,
+    "colors": [
+      "Pink"
+    ],
+    "sizes": [
+      "9",
+      "6",
+      "12",
+      "8",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "durable",
+      "best-seller",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-390-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-390-cloudbloc/240/180",
+    "created_at": "2024-10-08",
+    "description": "Lightweight yet durable, the Aero Runner 66 by Cloudbloc delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1391",
+    "name": "Volt Lantern 59",
+    "brand": "Northpeak",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 147.95,
+    "rating": 3.5,
+    "reviews": 667,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "water-resistant",
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-391-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-391-northpeak/240/180",
+    "created_at": "2025-04-14",
+    "description": "Northpeak's Volt Lantern 59 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1392",
+    "name": "Neo Chair 293",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 167.92,
+    "rating": 4.4,
+    "reviews": 1655,
+    "colors": [
+      "White",
+      "Pink",
+      "Navy",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "new",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-392-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-392-cloudbloc/240/180",
+    "created_at": "2025-08-17",
+    "description": "Neo Chair 293 from Cloudbloc is a versatile outdoors built for everyday use."
+  },
+  {
+    "id": "sku_1393",
+    "name": "Zen Flask 326",
+    "brand": "TrailForge",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 39.96,
+    "rating": 4.7,
+    "reviews": 1721,
+    "colors": [
+      "Olive",
+      "Purple"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-393-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-393-trailforge/240/180",
+    "created_at": "2025-06-30",
+    "description": "Zen Flask 326 from TrailForge is a versatile accessories built for everyday use."
+  },
+  {
+    "id": "sku_1394",
+    "name": "Ion Prime 140",
+    "brand": "PolarGrid",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 77.4,
+    "rating": 4.7,
+    "reviews": 973,
+    "colors": [
+      "Navy",
+      "Volt",
+      "White",
+      "Olive"
+    ],
+    "sizes": [
+      "12",
+      "8",
+      "9",
+      "11",
+      "6",
+      "7",
+      "10"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-394-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-394-polargrid/240/180",
+    "created_at": "2025-05-31",
+    "description": "Designed for comfort and durability, the Ion Prime 140 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1395",
+    "name": "Aero Knife Set 110",
+    "brand": "Zenwave",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 101.85,
+    "rating": 4.7,
+    "reviews": 1921,
+    "colors": [
+      "Olive",
+      "Pink",
+      "Red",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-395-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-395-zenwave/240/180",
+    "created_at": "2025-07-27",
+    "description": "The Aero Knife Set 110 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1396",
+    "name": "Trail Watch 383",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 366.83,
+    "rating": 4.0,
+    "reviews": 891,
+    "colors": [
+      "Volt",
+      "White",
+      "Navy",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "2025",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-396-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-396-zenwave/240/180",
+    "created_at": "2025-02-03",
+    "description": "Zenwave's Trail Watch 383 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1397",
+    "name": "Trail Hoodie 77",
+    "brand": "TrailForge",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 98.38,
+    "rating": 3.9,
+    "reviews": 1694,
+    "colors": [
+      "Tan",
+      "Purple",
+      "Red"
+    ],
+    "sizes": [
+      "XL",
+      "L",
+      "S",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-397-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-397-trailforge/240/180",
+    "created_at": "2024-11-18",
+    "description": "The Trail Hoodie 77 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1398",
+    "name": "Cumulus Daypack 494",
+    "brand": "Seoulistic",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 142.53,
+    "rating": 4.7,
+    "reviews": 113,
+    "colors": [
+      "Volt"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-398-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-398-seoulistic/240/180",
+    "created_at": "2025-04-06",
+    "description": "Seoulistic's Cumulus Daypack 494 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1399",
+    "name": "Ion Tee 268",
+    "brand": "Voltline",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 59.18,
+    "rating": 4.4,
+    "reviews": 1587,
+    "colors": [
+      "Tan",
+      "White",
+      "Navy"
+    ],
+    "sizes": [
+      "M",
+      "XXL",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "durable",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-399-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-399-voltline/240/180",
+    "created_at": "2025-01-08",
+    "description": "Lightweight yet durable, the Ion Tee 268 by Voltline delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1400",
+    "name": "Urban Performance Tee 210 · 한정판",
+    "brand": "Voltline",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 33.77,
+    "rating": 4.4,
+    "reviews": 1004,
+    "colors": [
+      "블랙",
+      "네이비",
+      "Purple",
+      "White",
+      "Volt"
+    ],
+    "sizes": [
+      "L",
+      "S",
+      "M",
+      "XS",
+      "XL",
+      "XXL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-400-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-400-voltline/240/180",
+    "created_at": "2025-02-14",
+    "description": "Urban Performance Tee 210 · 한정판 from Voltline is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1401",
+    "name": "Urban Racer 197",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 130.2,
+    "rating": 4.9,
+    "reviews": 743,
+    "colors": [
+      "Red"
+    ],
+    "sizes": [
+      "12",
+      "9",
+      "11",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-401-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-401-voltline/240/180",
+    "created_at": "2025-03-30",
+    "description": "Urban Racer 197 from Voltline is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1402",
+    "name": "Cumulus Commuter 324",
+    "brand": "Voltline",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 87.82,
+    "rating": 4.7,
+    "reviews": 1319,
+    "colors": [
+      "Black",
+      "Olive",
+      "White",
+      "Tan"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "2025",
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-402-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-402-voltline/240/180",
+    "created_at": "2025-02-27",
+    "description": "Voltline's Cumulus Commuter 324 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1403",
+    "name": "Volt Carry 216",
+    "brand": "Seoulistic",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 126.29,
+    "rating": 4.7,
+    "reviews": 1510,
+    "colors": [
+      "Tan",
+      "Black",
+      "Pink"
+    ],
+    "sizes": [
+      "20L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-403-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-403-seoulistic/240/180",
+    "created_at": "2025-08-04",
+    "description": "Lightweight yet durable, the Volt Carry 216 by Seoulistic delivers outstanding quality for bags enthusiasts."
+  },
+  {
+    "id": "sku_1404",
+    "name": "Neo Anorak 43",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 82.17,
+    "rating": 3.9,
+    "reviews": 1461,
+    "colors": [
+      "Blue",
+      "Pink"
+    ],
+    "sizes": [
+      "L",
+      "M",
+      "XL",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller",
+      "water-resistant",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-404-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-404-nimbusworks/240/180",
+    "created_at": "2025-08-27",
+    "description": "Designed for comfort and durability, the Neo Anorak 43 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1405",
+    "name": "Flux Street 202",
+    "brand": "TrailForge",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 166.4,
+    "rating": 4.9,
+    "reviews": 1811,
+    "colors": [
+      "Black",
+      "Purple"
+    ],
+    "sizes": [
+      "11",
+      "10",
+      "7",
+      "6",
+      "12",
+      "9",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-405-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-405-trailforge/240/180",
+    "created_at": "2024-12-05",
+    "description": "Flux Street 202 from TrailForge is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1406",
+    "name": "Urban Earbuds 46",
+    "brand": "PolarGrid",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 383.47,
+    "rating": 3.8,
+    "reviews": 1161,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-406-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-406-polargrid/240/180",
+    "created_at": "2025-04-20",
+    "description": "Designed for comfort and durability, the Urban Earbuds 46 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1407",
+    "name": "Urban Puffer 383",
+    "brand": "Voltline",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 158.83,
+    "rating": 3.7,
+    "reviews": 1753,
+    "colors": [
+      "Blue",
+      "Navy"
+    ],
+    "sizes": [
+      "M",
+      "XL",
+      "S",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "durable",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-407-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-407-voltline/240/180",
+    "created_at": "2024-09-24",
+    "description": "Urban Puffer 383 from Voltline is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1408",
+    "name": "Flux Tracker 351",
+    "brand": "Voltline",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 350.84,
+    "rating": 3.6,
+    "reviews": 960,
+    "colors": [
+      "Volt",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-408-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-408-voltline/240/180",
+    "created_at": "2025-09-10",
+    "description": "Lightweight yet durable, the Flux Tracker 351 by Voltline delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1409",
+    "name": "Ion Daypack 27",
+    "brand": "Northpeak",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 89.94,
+    "rating": 3.9,
+    "reviews": 1860,
+    "colors": [
+      "Blue",
+      "Pink",
+      "Purple"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "best-seller",
+      "water-resistant",
+      "eco",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-409-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-409-northpeak/240/180",
+    "created_at": "2025-05-26",
+    "description": "Designed for comfort and durability, the Ion Daypack 27 is perfect for bags needs."
+  },
+  {
+    "id": "sku_1410",
+    "name": "Nimbus Tech Tee 134",
+    "brand": "Seoulistic",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 28.53,
+    "rating": 4.2,
+    "reviews": 694,
+    "colors": [
+      "Gray",
+      "White",
+      "Volt",
+      "Red"
+    ],
+    "sizes": [
+      "S",
+      "M",
+      "XS",
+      "XXL",
+      "L",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "eco",
+      "water-resistant",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-410-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-410-seoulistic/240/180",
+    "created_at": "2025-01-31",
+    "description": "Designed for comfort and durability, the Nimbus Tech Tee 134 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1411",
+    "name": "Summit Lantern 224",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 358.32,
+    "rating": 4.0,
+    "reviews": 1006,
+    "colors": [
+      "Red",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-411-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-411-nimbusworks/240/180",
+    "created_at": "2025-04-23",
+    "description": "The Summit Lantern 224 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1412",
+    "name": "Cumulus Runner 241",
+    "brand": "Voltline",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 123.83,
+    "rating": 4.6,
+    "reviews": 893,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [
+      "9",
+      "8",
+      "10"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-412-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-412-voltline/240/180",
+    "created_at": "2025-05-20",
+    "description": "The Cumulus Runner 241 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1413",
+    "name": "Zen Flask 93",
+    "brand": "Northpeak",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 39.55,
+    "rating": 4.6,
+    "reviews": 1684,
+    "colors": [
+      "Blue",
+      "Pink",
+      "Purple"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "eco",
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-413-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-413-northpeak/240/180",
+    "created_at": "2024-09-12",
+    "description": "Lightweight yet durable, the Zen Flask 93 by Northpeak delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1414",
+    "name": "Neo Watch 146",
+    "brand": "Northpeak",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 365.15,
+    "rating": 4.5,
+    "reviews": 807,
+    "colors": [
+      "Blue",
+      "White",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-414-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-414-northpeak/240/180",
+    "created_at": "2024-10-21",
+    "description": "Neo Watch 146 from Northpeak is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1415",
+    "name": "Aurora Carry 497",
+    "brand": "PolarGrid",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 50.92,
+    "rating": 4.4,
+    "reviews": 927,
+    "colors": [
+      "Purple",
+      "Blue",
+      "Gray"
+    ],
+    "sizes": [
+      "20L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-415-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-415-polargrid/240/180",
+    "created_at": "2025-08-05",
+    "description": "Designed for comfort and durability, the Aurora Carry 497 is perfect for bags needs."
+  },
+  {
+    "id": "sku_1416",
+    "name": "Tempo Daily 48",
+    "brand": "Seoulistic",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 113.87,
+    "rating": 3.8,
+    "reviews": 1976,
+    "colors": [
+      "White",
+      "Black",
+      "Navy",
+      "Gray"
+    ],
+    "sizes": [
+      "12",
+      "9",
+      "8",
+      "7",
+      "6",
+      "11"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "limited",
+      "2025",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-416-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-416-seoulistic/240/180",
+    "created_at": "2025-04-19",
+    "description": "Designed for comfort and durability, the Tempo Daily 48 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1417",
+    "name": "Flux Bottle 251",
+    "brand": "Northpeak",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 26.7,
+    "rating": 4.1,
+    "reviews": 549,
+    "colors": [
+      "White",
+      "Forest",
+      "Volt",
+      "Gray"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-417-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-417-northpeak/240/180",
+    "created_at": "2024-10-27",
+    "description": "The Flux Bottle 251 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1418",
+    "name": "Atlas Anorak 323",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 189.45,
+    "rating": 3.6,
+    "reviews": 958,
+    "colors": [
+      "White",
+      "Tan",
+      "Olive",
+      "Gray"
+    ],
+    "sizes": [
+      "L",
+      "S",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "lightweight",
+      "new",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-418-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-418-zenwave/240/180",
+    "created_at": "2024-10-04",
+    "description": "Lightweight yet durable, the Atlas Anorak 323 by Zenwave delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1419",
+    "name": "Pulse Kettle 238",
+    "brand": "TrailForge",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 101.86,
+    "rating": 4.4,
+    "reviews": 518,
+    "colors": [
+      "Olive",
+      "Blue",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-419-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-419-trailforge/240/180",
+    "created_at": "2024-09-18",
+    "description": "Designed for comfort and durability, the Pulse Kettle 238 is perfect for home needs."
+  },
+  {
+    "id": "sku_1420",
+    "name": "Nimbus Tee 214",
+    "brand": "TrailForge",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 72.36,
+    "rating": 3.9,
+    "reviews": 1202,
+    "colors": [
+      "Pink",
+      "Tan",
+      "Blue",
+      "Olive"
+    ],
+    "sizes": [
+      "S",
+      "XXL",
+      "XL",
+      "XS",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "2025",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-420-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-420-trailforge/240/180",
+    "created_at": "2024-11-03",
+    "description": "TrailForge's Nimbus Tee 214 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1421",
+    "name": "Cumulus Daily 236",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 146.1,
+    "rating": 4.8,
+    "reviews": 1977,
+    "colors": [
+      "Olive",
+      "Blue",
+      "Pink",
+      "Volt"
+    ],
+    "sizes": [
+      "12",
+      "8",
+      "6",
+      "7",
+      "10",
+      "11"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "best-seller",
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-421-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-421-cloudbloc/240/180",
+    "created_at": "2024-09-18",
+    "description": "Designed for comfort and durability, the Cumulus Daily 236 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1422",
+    "name": "Trail Band 432",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 341.94,
+    "rating": 4.7,
+    "reviews": 390,
+    "colors": [
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "lightweight",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-422-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-422-zenwave/240/180",
+    "created_at": "2024-11-24",
+    "description": "Lightweight yet durable, the Trail Band 432 by Zenwave delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1423",
+    "name": "Glide Performance Tee 242",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 19.22,
+    "rating": 4.2,
+    "reviews": 496,
+    "colors": [
+      "Olive",
+      "Blue"
+    ],
+    "sizes": [
+      "XS",
+      "M",
+      "XXL",
+      "L",
+      "S",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "lightweight",
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-423-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-423-zenwave/240/180",
+    "created_at": "2025-07-03",
+    "description": "The Glide Performance Tee 242 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1424",
+    "name": "Aero Tracker 314",
+    "brand": "Seoulistic",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 471.82,
+    "rating": 4.9,
+    "reviews": 1776,
+    "colors": [
+      "Navy",
+      "Black",
+      "Red",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "water-resistant",
+      "limited",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-424-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-424-seoulistic/240/180",
+    "created_at": "2025-02-18",
+    "description": "Lightweight yet durable, the Aero Tracker 314 by Seoulistic delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1425",
+    "name": "Atlas Tracker 481",
+    "brand": "Northpeak",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 350.4,
+    "rating": 4.2,
+    "reviews": 893,
+    "colors": [
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "eco",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-425-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-425-northpeak/240/180",
+    "created_at": "2024-12-17",
+    "description": "Atlas Tracker 481 from Northpeak is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1426",
+    "name": "Aero Mug 472",
+    "brand": "Voltline",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 93.69,
+    "rating": 4.8,
+    "reviews": 1345,
+    "colors": [
+      "Gray",
+      "Olive",
+      "Forest",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "best-seller",
+      "eco",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-426-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-426-voltline/240/180",
+    "created_at": "2025-08-20",
+    "description": "Aero Mug 472 from Voltline is a versatile home built for everyday use."
+  },
+  {
+    "id": "sku_1427",
+    "name": "Polar Tent 342",
+    "brand": "Voltline",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 203.02,
+    "rating": 3.8,
+    "reviews": 320,
+    "colors": [
+      "White",
+      "Forest",
+      "Tan",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-427-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-427-voltline/240/180",
+    "created_at": "2025-06-22",
+    "description": "Designed for comfort and durability, the Polar Tent 342 is perfect for outdoors needs."
+  },
+  {
+    "id": "sku_1428",
+    "name": "Cumulus Pack 424",
+    "brand": "AuroraLab",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 161.03,
+    "rating": 4.3,
+    "reviews": 1652,
+    "colors": [
+      "Volt"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": false,
+    "tags": [
+      "eco",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-428-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-428-auroralab/240/180",
+    "created_at": "2025-01-04",
+    "description": "Lightweight yet durable, the Cumulus Pack 424 by AuroraLab delivers outstanding quality for bags enthusiasts."
+  },
+  {
+    "id": "sku_1429",
+    "name": "Flux Daypack 395",
+    "brand": "AuroraLab",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 163.49,
+    "rating": 3.9,
+    "reviews": 309,
+    "colors": [
+      "Purple"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "lightweight",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-429-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-429-auroralab/240/180",
+    "created_at": "2025-04-22",
+    "description": "The Flux Daypack 395 combines modern style with reliable performance in bags gear."
+  },
+  {
+    "id": "sku_1430",
+    "name": "Wave Tent 260",
+    "brand": "Northpeak",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 59.95,
+    "rating": 4.4,
+    "reviews": 1783,
+    "colors": [
+      "Volt",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "limited",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-430-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-430-northpeak/240/180",
+    "created_at": "2025-09-07",
+    "description": "The Wave Tent 260 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1431",
+    "name": "Neo Tech Tee 63",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 70.61,
+    "rating": 4.2,
+    "reviews": 851,
+    "colors": [
+      "Navy"
+    ],
+    "sizes": [
+      "M",
+      "XXL",
+      "S",
+      "XS",
+      "L",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-431-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-431-auroralab/240/180",
+    "created_at": "2025-04-10",
+    "description": "AuroraLab's Neo Tech Tee 63 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1432",
+    "name": "Stratus Headphones 212",
+    "brand": "Voltline",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 368.67,
+    "rating": 4.8,
+    "reviews": 1949,
+    "colors": [
+      "Black",
+      "Tan",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-432-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-432-voltline/240/180",
+    "created_at": "2025-06-01",
+    "description": "Designed for comfort and durability, the Stratus Headphones 212 is perfect for electronics needs."
+  },
+  {
+    "id": "sku_1433",
+    "name": "Cumulus Flask 32",
+    "brand": "TrailForge",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 24.98,
+    "rating": 3.6,
+    "reviews": 1889,
+    "colors": [
+      "Blue",
+      "Black"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco",
+      "best-seller",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-433-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-433-trailforge/240/180",
+    "created_at": "2025-08-14",
+    "description": "Lightweight yet durable, the Cumulus Flask 32 by TrailForge delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1434",
+    "name": "Flux Daypack 424",
+    "brand": "AuroraLab",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 82.77,
+    "rating": 4.3,
+    "reviews": 1885,
+    "colors": [
+      "Purple",
+      "Forest"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "limited",
+      "water-resistant",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-434-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-434-auroralab/240/180",
+    "created_at": "2025-06-15",
+    "description": "Designed for comfort and durability, the Flux Daypack 424 is perfect for bags needs."
+  },
+  {
+    "id": "sku_1435",
+    "name": "Volt Hoodie 276",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 126.9,
+    "rating": 4.6,
+    "reviews": 1515,
+    "colors": [
+      "Red",
+      "Purple"
+    ],
+    "sizes": [
+      "M",
+      "S",
+      "XL",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-435-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-435-nimbusworks/240/180",
+    "created_at": "2024-11-30",
+    "description": "The Volt Hoodie 276 combines modern style with reliable performance in apparel gear."
+  },
+  {
+    "id": "sku_1436",
+    "name": "Urban Pan 427",
+    "brand": "PolarGrid",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 117.61,
+    "rating": 4.6,
+    "reviews": 1034,
+    "colors": [
+      "Purple"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "limited",
+      "lightweight",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-436-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-436-polargrid/240/180",
+    "created_at": "2025-03-19",
+    "description": "Designed for comfort and durability, the Urban Pan 427 is perfect for home needs."
+  },
+  {
+    "id": "sku_1437",
+    "name": "Polar Classic 233",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 107.29,
+    "rating": 3.9,
+    "reviews": 1527,
+    "colors": [
+      "Volt",
+      "Olive"
+    ],
+    "sizes": [
+      "11",
+      "12",
+      "10",
+      "7",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-437-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-437-urbanmesh/240/180",
+    "created_at": "2025-01-14",
+    "description": "UrbanMesh's Polar Classic 233 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1438",
+    "name": "Flux Chair 51",
+    "brand": "Voltline",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 75.54,
+    "rating": 4.1,
+    "reviews": 843,
+    "colors": [
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "eco",
+      "2025",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-438-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-438-voltline/240/180",
+    "created_at": "2024-11-15",
+    "description": "The Flux Chair 51 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1439",
+    "name": "Echo Flask 447",
+    "brand": "Seoulistic",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 20.7,
+    "rating": 4.2,
+    "reviews": 867,
+    "colors": [
+      "Purple",
+      "Tan",
+      "Forest",
+      "Gray"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "durable",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-439-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-439-seoulistic/240/180",
+    "created_at": "2025-05-16",
+    "description": "The Echo Flask 447 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1440",
+    "name": "Zen Knife Set 243",
+    "brand": "Northpeak",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 14.53,
+    "rating": 3.7,
+    "reviews": 1144,
+    "colors": [
+      "White",
+      "Blue",
+      "Forest"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "new",
+      "lightweight",
+      "2025",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-440-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-440-northpeak/240/180",
+    "created_at": "2025-03-18",
+    "description": "Designed for comfort and durability, the Zen Knife Set 243 is perfect for home needs."
+  },
+  {
+    "id": "sku_1441",
+    "name": "Polar Prime 156",
+    "brand": "AuroraLab",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 102.34,
+    "rating": 3.5,
+    "reviews": 292,
+    "colors": [
+      "Blue",
+      "Forest"
+    ],
+    "sizes": [
+      "8",
+      "12",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-441-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-441-auroralab/240/180",
+    "created_at": "2025-05-18",
+    "description": "AuroraLab's Polar Prime 156 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1442",
+    "name": "Nimbus Flask 247",
+    "brand": "Northpeak",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 30.91,
+    "rating": 4.3,
+    "reviews": 1843,
+    "colors": [
+      "Forest",
+      "Tan",
+      "Blue"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "best-seller",
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-442-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-442-northpeak/240/180",
+    "created_at": "2025-05-26",
+    "description": "Lightweight yet durable, the Nimbus Flask 247 by Northpeak delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1443",
+    "name": "Volt Performance Tee 199",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 32.43,
+    "rating": 4.1,
+    "reviews": 1107,
+    "colors": [
+      "Pink"
+    ],
+    "sizes": [
+      "XXL",
+      "M",
+      "XS",
+      "L",
+      "XL",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "2025",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-443-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-443-auroralab/240/180",
+    "created_at": "2024-11-12",
+    "description": "Designed for comfort and durability, the Volt Performance Tee 199 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1444",
+    "name": "Aero Stove 385",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 200.34,
+    "rating": 4.8,
+    "reviews": 246,
+    "colors": [
+      "Black",
+      "Olive"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-444-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-444-cloudbloc/240/180",
+    "created_at": "2025-01-13",
+    "description": "Cloudbloc's Aero Stove 385 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1445",
+    "name": "Aero Bottle 252",
+    "brand": "TrailForge",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 40.45,
+    "rating": 3.5,
+    "reviews": 895,
+    "colors": [
+      "Forest",
+      "Black"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-445-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-445-trailforge/240/180",
+    "created_at": "2025-01-19",
+    "description": "Lightweight yet durable, the Aero Bottle 252 by TrailForge delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1446",
+    "name": "Polar Pan 94",
+    "brand": "Zenwave",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 45.52,
+    "rating": 3.6,
+    "reviews": 628,
+    "colors": [
+      "Pink",
+      "Gray",
+      "Black",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-446-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-446-zenwave/240/180",
+    "created_at": "2025-09-10",
+    "description": "The Polar Pan 94 combines modern style with reliable performance in home gear."
+  },
+  {
+    "id": "sku_1447",
+    "name": "Stratus Daily 458",
+    "brand": "AuroraLab",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 105.66,
+    "rating": 4.1,
+    "reviews": 1695,
+    "colors": [
+      "Black"
+    ],
+    "sizes": [
+      "7",
+      "10",
+      "11",
+      "12"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "water-resistant",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-447-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-447-auroralab/240/180",
+    "created_at": "2025-05-26",
+    "description": "Lightweight yet durable, the Stratus Daily 458 by AuroraLab delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1448",
+    "name": "Wave Flask 34",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 27.98,
+    "rating": 4.1,
+    "reviews": 478,
+    "colors": [
+      "Olive"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-448-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-448-urbanmesh/240/180",
+    "created_at": "2025-08-21",
+    "description": "Lightweight yet durable, the Wave Flask 34 by UrbanMesh delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1449",
+    "name": "Polar Knife Set 229",
+    "brand": "Zenwave",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 21.66,
+    "rating": 4.5,
+    "reviews": 416,
+    "colors": [
+      "Volt",
+      "Red"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "new",
+      "eco",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-449-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-449-zenwave/240/180",
+    "created_at": "2025-01-13",
+    "description": "Polar Knife Set 229 from Zenwave is a versatile home built for everyday use."
+  },
+  {
+    "id": "sku_1450",
+    "name": "Tempo Stride 335 · 한정판",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 216.37,
+    "rating": 3.5,
+    "reviews": 1911,
+    "colors": [
+      "블랙",
+      "네이비",
+      "Purple",
+      "Olive",
+      "Blue",
+      "Forest"
+    ],
+    "sizes": [
+      "12",
+      "11",
+      "7",
+      "8",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "water-resistant",
+      "lightweight",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-450-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-450-urbanmesh/240/180",
+    "created_at": "2025-06-10",
+    "description": "Lightweight yet durable, the Tempo Stride 335 · 한정판 by UrbanMesh delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1451",
+    "name": "Wave Prime 450",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 117.52,
+    "rating": 4.4,
+    "reviews": 1960,
+    "colors": [
+      "Pink",
+      "Volt",
+      "Olive"
+    ],
+    "sizes": [
+      "8",
+      "7",
+      "12",
+      "10",
+      "6",
+      "11"
+    ],
+    "in_stock": true,
+    "tags": [
+      "water-resistant",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-451-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-451-zenwave/240/180",
+    "created_at": "2025-02-25",
+    "description": "Lightweight yet durable, the Wave Prime 450 by Zenwave delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1452",
+    "name": "Atlas Runner 462",
+    "brand": "PolarGrid",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 91.25,
+    "rating": 3.8,
+    "reviews": 1138,
+    "colors": [
+      "Forest",
+      "Red",
+      "White",
+      "Blue"
+    ],
+    "sizes": [
+      "6",
+      "11",
+      "9",
+      "12",
+      "7",
+      "8",
+      "10"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-452-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-452-polargrid/240/180",
+    "created_at": "2025-09-01",
+    "description": "The Atlas Runner 462 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1453",
+    "name": "Glide Bottle 114",
+    "brand": "Voltline",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 36.52,
+    "rating": 4.6,
+    "reviews": 1393,
+    "colors": [
+      "Navy",
+      "White",
+      "Blue"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-453-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-453-voltline/240/180",
+    "created_at": "2025-01-01",
+    "description": "The Glide Bottle 114 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1454",
+    "name": "Atlas Racer 108",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 90.93,
+    "rating": 5.0,
+    "reviews": 1307,
+    "colors": [
+      "White",
+      "Olive",
+      "Blue",
+      "Red"
+    ],
+    "sizes": [
+      "7",
+      "10",
+      "12",
+      "11",
+      "6",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-454-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-454-nimbusworks/240/180",
+    "created_at": "2024-11-14",
+    "description": "Lightweight yet durable, the Atlas Racer 108 by NimbusWorks delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1455",
+    "name": "Aurora Carry 349",
+    "brand": "Voltline",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 120.62,
+    "rating": 4.2,
+    "reviews": 1920,
+    "colors": [
+      "Pink",
+      "Purple",
+      "Black",
+      "Volt"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-455-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-455-voltline/240/180",
+    "created_at": "2025-04-06",
+    "description": "Designed for comfort and durability, the Aurora Carry 349 is perfect for bags needs."
+  },
+  {
+    "id": "sku_1456",
+    "name": "Flux Tracker 389",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 97.26,
+    "rating": 4.6,
+    "reviews": 96,
+    "colors": [
+      "Forest",
+      "Red",
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-456-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-456-urbanmesh/240/180",
+    "created_at": "2025-03-29",
+    "description": "Flux Tracker 389 from UrbanMesh is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1457",
+    "name": "Trail Chair 491",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 48.21,
+    "rating": 3.9,
+    "reviews": 336,
+    "colors": [
+      "Olive",
+      "White",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "limited",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-457-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-457-cloudbloc/240/180",
+    "created_at": "2025-04-19",
+    "description": "Trail Chair 491 from Cloudbloc is a versatile outdoors built for everyday use."
+  },
+  {
+    "id": "sku_1458",
+    "name": "Ion Commuter 123",
+    "brand": "Voltline",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 174.44,
+    "rating": 4.7,
+    "reviews": 1682,
+    "colors": [
+      "Red",
+      "Navy",
+      "White"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "lightweight",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-458-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-458-voltline/240/180",
+    "created_at": "2025-07-27",
+    "description": "Designed for comfort and durability, the Ion Commuter 123 is perfect for bags needs."
+  },
+  {
+    "id": "sku_1459",
+    "name": "Neo Runner 401",
+    "brand": "TrailForge",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 106.58,
+    "rating": 4.9,
+    "reviews": 905,
+    "colors": [
+      "Olive"
+    ],
+    "sizes": [
+      "11",
+      "9",
+      "6",
+      "10",
+      "8",
+      "12",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "new",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-459-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-459-trailforge/240/180",
+    "created_at": "2025-03-24",
+    "description": "Designed for comfort and durability, the Neo Runner 401 is perfect for shoes needs."
+  },
+  {
+    "id": "sku_1460",
+    "name": "Tempo Hoodie 233",
+    "brand": "PolarGrid",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 136.78,
+    "rating": 4.7,
+    "reviews": 1802,
+    "colors": [
+      "Volt"
+    ],
+    "sizes": [
+      "XL",
+      "L",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-460-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-460-polargrid/240/180",
+    "created_at": "2024-11-04",
+    "description": "Lightweight yet durable, the Tempo Hoodie 233 by PolarGrid delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1461",
+    "name": "Zen Street 327",
+    "brand": "PolarGrid",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 125.98,
+    "rating": 4.0,
+    "reviews": 985,
+    "colors": [
+      "Gray",
+      "Navy",
+      "Purple",
+      "Black"
+    ],
+    "sizes": [
+      "7",
+      "8",
+      "10"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-461-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-461-polargrid/240/180",
+    "created_at": "2025-08-09",
+    "description": "Zen Street 327 from PolarGrid is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1462",
+    "name": "Atlas Crew 309",
+    "brand": "Zenwave",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 39.26,
+    "rating": 4.1,
+    "reviews": 16,
+    "colors": [
+      "Black",
+      "Navy"
+    ],
+    "sizes": [
+      "L",
+      "M",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-462-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-462-zenwave/240/180",
+    "created_at": "2025-08-03",
+    "description": "Designed for comfort and durability, the Atlas Crew 309 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1463",
+    "name": "Glide Anorak 355",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 126.23,
+    "rating": 4.4,
+    "reviews": 1972,
+    "colors": [
+      "Blue",
+      "Olive",
+      "Forest"
+    ],
+    "sizes": [
+      "M",
+      "S",
+      "XL",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "limited",
+      "durable",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-463-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-463-urbanmesh/240/180",
+    "created_at": "2024-09-11",
+    "description": "Lightweight yet durable, the Glide Anorak 355 by UrbanMesh delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1464",
+    "name": "Trail Chair 377",
+    "brand": "Voltline",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 311.2,
+    "rating": 4.7,
+    "reviews": 1653,
+    "colors": [
+      "Navy",
+      "Forest",
+      "Gray",
+      "Black"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-464-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-464-voltline/240/180",
+    "created_at": "2024-10-17",
+    "description": "The Trail Chair 377 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1465",
+    "name": "Glide Tech Tee 324",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 54.31,
+    "rating": 4.6,
+    "reviews": 89,
+    "colors": [
+      "Navy"
+    ],
+    "sizes": [
+      "M",
+      "S",
+      "XL",
+      "L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "durable",
+      "best-seller",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-465-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-465-nimbusworks/240/180",
+    "created_at": "2025-03-02",
+    "description": "Designed for comfort and durability, the Glide Tech Tee 324 is perfect for apparel needs."
+  },
+  {
+    "id": "sku_1466",
+    "name": "Ion Tee 426",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 60.0,
+    "rating": 4.1,
+    "reviews": 1612,
+    "colors": [
+      "Volt"
+    ],
+    "sizes": [
+      "M",
+      "L",
+      "S",
+      "XL"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-466-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-466-nimbusworks/240/180",
+    "created_at": "2025-08-14",
+    "description": "NimbusWorks's Ion Tee 426 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1467",
+    "name": "Stratus Street 407",
+    "brand": "Northpeak",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 90.86,
+    "rating": 4.3,
+    "reviews": 1422,
+    "colors": [
+      "Volt",
+      "Blue",
+      "Forest"
+    ],
+    "sizes": [
+      "6",
+      "10",
+      "11",
+      "7"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-467-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-467-northpeak/240/180",
+    "created_at": "2025-02-07",
+    "description": "The Stratus Street 407 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1468",
+    "name": "Stratus Racer 496",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 165.93,
+    "rating": 4.2,
+    "reviews": 1489,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [
+      "6",
+      "7",
+      "10",
+      "9",
+      "8",
+      "11",
+      "12"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "new",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-468-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-468-nimbusworks/240/180",
+    "created_at": "2024-12-10",
+    "description": "Lightweight yet durable, the Stratus Racer 496 by NimbusWorks delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1469",
+    "name": "Atlas Band 298",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 247.4,
+    "rating": 4.9,
+    "reviews": 1195,
+    "colors": [
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "2025",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-469-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-469-urbanmesh/240/180",
+    "created_at": "2024-12-22",
+    "description": "The Atlas Band 298 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1470",
+    "name": "Echo Pack 479",
+    "brand": "TrailForge",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 158.73,
+    "rating": 3.9,
+    "reviews": 173,
+    "colors": [
+      "White",
+      "Olive"
+    ],
+    "sizes": [
+      "28L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "eco",
+      "new",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-470-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-470-trailforge/240/180",
+    "created_at": "2025-01-05",
+    "description": "Lightweight yet durable, the Echo Pack 479 by TrailForge delivers outstanding quality for bags enthusiasts."
+  },
+  {
+    "id": "sku_1471",
+    "name": "Glide Flask 222",
+    "brand": "TrailForge",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 25.5,
+    "rating": 4.7,
+    "reviews": 649,
+    "colors": [
+      "Forest",
+      "Black",
+      "Gray"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-471-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-471-trailforge/240/180",
+    "created_at": "2025-08-06",
+    "description": "Lightweight yet durable, the Glide Flask 222 by TrailForge delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1472",
+    "name": "Summit Daypack 403",
+    "brand": "Seoulistic",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 82.32,
+    "rating": 3.8,
+    "reviews": 242,
+    "colors": [
+      "Volt"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "limited",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-472-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-472-seoulistic/240/180",
+    "created_at": "2025-02-27",
+    "description": "Summit Daypack 403 from Seoulistic is a versatile bags built for everyday use."
+  },
+  {
+    "id": "sku_1473",
+    "name": "Zen Pack 438",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 146.57,
+    "rating": 4.6,
+    "reviews": 1868,
+    "colors": [
+      "Black",
+      "Olive",
+      "Pink"
+    ],
+    "sizes": [
+      "24L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "eco",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-473-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-473-nimbusworks/240/180",
+    "created_at": "2025-04-04",
+    "description": "Lightweight yet durable, the Zen Pack 438 by NimbusWorks delivers outstanding quality for bags enthusiasts."
+  },
+  {
+    "id": "sku_1474",
+    "name": "Echo Pan 117",
+    "brand": "Zenwave",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 110.54,
+    "rating": 3.8,
+    "reviews": 478,
+    "colors": [
+      "Purple",
+      "Tan",
+      "Volt",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "durable",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-474-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-474-zenwave/240/180",
+    "created_at": "2024-12-15",
+    "description": "Echo Pan 117 from Zenwave is a versatile home built for everyday use."
+  },
+  {
+    "id": "sku_1475",
+    "name": "Aurora Band 72",
+    "brand": "Seoulistic",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 321.55,
+    "rating": 3.7,
+    "reviews": 1931,
+    "colors": [
+      "Tan"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "2025",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-475-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-475-seoulistic/240/180",
+    "created_at": "2025-03-10",
+    "description": "Lightweight yet durable, the Aurora Band 72 by Seoulistic delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1476",
+    "name": "Polar Headphones 301",
+    "brand": "Seoulistic",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 37.6,
+    "rating": 4.7,
+    "reviews": 1888,
+    "colors": [
+      "Gray",
+      "Volt"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "eco",
+      "durable",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-476-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-476-seoulistic/240/180",
+    "created_at": "2025-07-15",
+    "description": "The Polar Headphones 301 combines modern style with reliable performance in electronics gear."
+  },
+  {
+    "id": "sku_1477",
+    "name": "Echo Street 244",
+    "brand": "Seoulistic",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 81.95,
+    "rating": 4.4,
+    "reviews": 924,
+    "colors": [
+      "White",
+      "Gray",
+      "Purple"
+    ],
+    "sizes": [
+      "7",
+      "6",
+      "10",
+      "9",
+      "11",
+      "8",
+      "12"
+    ],
+    "in_stock": false,
+    "tags": [
+      "eco",
+      "durable",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-477-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-477-seoulistic/240/180",
+    "created_at": "2025-03-26",
+    "description": "Echo Street 244 from Seoulistic is a versatile shoes built for everyday use."
+  },
+  {
+    "id": "sku_1478",
+    "name": "Glide Kettle 189",
+    "brand": "Northpeak",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 82.08,
+    "rating": 3.8,
+    "reviews": 1760,
+    "colors": [
+      "Forest",
+      "Gray",
+      "White",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "eco",
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-478-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-478-northpeak/240/180",
+    "created_at": "2025-05-12",
+    "description": "Northpeak's Glide Kettle 189 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1479",
+    "name": "Pulse Jacket 82",
+    "brand": "NimbusWorks",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 180.74,
+    "rating": 4.9,
+    "reviews": 1203,
+    "colors": [
+      "Red",
+      "Pink"
+    ],
+    "sizes": [
+      "L",
+      "S",
+      "XL",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "new",
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-479-nimbusworks/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-479-nimbusworks/240/180",
+    "created_at": "2025-04-02",
+    "description": "NimbusWorks's Pulse Jacket 82 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1480",
+    "name": "Glide Tracker 21",
+    "brand": "UrbanMesh",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 388.66,
+    "rating": 3.9,
+    "reviews": 1804,
+    "colors": [
+      "Volt",
+      "Olive",
+      "Forest",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "eco",
+      "2025",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-480-urbanmesh/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-480-urbanmesh/240/180",
+    "created_at": "2024-12-10",
+    "description": "Glide Tracker 21 from UrbanMesh is a versatile electronics built for everyday use."
+  },
+  {
+    "id": "sku_1481",
+    "name": "Echo Tent 123",
+    "brand": "Northpeak",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 355.62,
+    "rating": 3.7,
+    "reviews": 1807,
+    "colors": [
+      "Pink",
+      "White",
+      "Navy"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "water-resistant",
+      "lightweight",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-481-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-481-northpeak/240/180",
+    "created_at": "2025-04-08",
+    "description": "Northpeak's Echo Tent 123 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1482",
+    "name": "Pulse Knife Set 85",
+    "brand": "AuroraLab",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 45.13,
+    "rating": 4.3,
+    "reviews": 946,
+    "colors": [
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "eco",
+      "water-resistant",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-482-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-482-auroralab/240/180",
+    "created_at": "2025-08-21",
+    "description": "Pulse Knife Set 85 from AuroraLab is a versatile home built for everyday use."
+  },
+  {
+    "id": "sku_1483",
+    "name": "Nimbus Hoodie 129",
+    "brand": "TrailForge",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 82.94,
+    "rating": 4.9,
+    "reviews": 669,
+    "colors": [
+      "Tan",
+      "Purple",
+      "White",
+      "Blue"
+    ],
+    "sizes": [
+      "XL",
+      "S",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-483-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-483-trailforge/240/180",
+    "created_at": "2024-12-01",
+    "description": "Nimbus Hoodie 129 from TrailForge is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1484",
+    "name": "Polar Classic 274",
+    "brand": "Zenwave",
+    "categories": [
+      "Shoes",
+      "Lifestyle"
+    ],
+    "price": 151.56,
+    "rating": 3.8,
+    "reviews": 1375,
+    "colors": [
+      "Pink"
+    ],
+    "sizes": [
+      "7",
+      "9",
+      "8",
+      "12",
+      "6"
+    ],
+    "in_stock": true,
+    "tags": [
+      "eco",
+      "2025",
+      "limited",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-lifestyle-484-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-lifestyle-484-zenwave/240/180",
+    "created_at": "2025-08-21",
+    "description": "Lightweight yet durable, the Polar Classic 274 by Zenwave delivers outstanding quality for shoes enthusiasts."
+  },
+  {
+    "id": "sku_1485",
+    "name": "Echo Mug 228",
+    "brand": "Northpeak",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 17.29,
+    "rating": 3.5,
+    "reviews": 1581,
+    "colors": [
+      "Navy",
+      "Purple",
+      "Volt",
+      "Pink"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "2025",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-485-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-485-northpeak/240/180",
+    "created_at": "2024-09-18",
+    "description": "Northpeak's Echo Mug 228 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1486",
+    "name": "Trail Hoodie 409",
+    "brand": "Northpeak",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 227.08,
+    "rating": 4.5,
+    "reviews": 1482,
+    "colors": [
+      "Black",
+      "Forest"
+    ],
+    "sizes": [
+      "L",
+      "M",
+      "S"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-486-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-486-northpeak/240/180",
+    "created_at": "2025-06-14",
+    "description": "Lightweight yet durable, the Trail Hoodie 409 by Northpeak delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1487",
+    "name": "Flux Puffer 89",
+    "brand": "Northpeak",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 63.0,
+    "rating": 4.5,
+    "reviews": 24,
+    "colors": [
+      "Navy",
+      "Tan",
+      "Purple",
+      "White"
+    ],
+    "sizes": [
+      "L",
+      "S",
+      "XL",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "limited",
+      "new"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-487-northpeak/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-487-northpeak/240/180",
+    "created_at": "2025-07-13",
+    "description": "Lightweight yet durable, the Flux Puffer 89 by Northpeak delivers outstanding quality for apparel enthusiasts."
+  },
+  {
+    "id": "sku_1488",
+    "name": "Urban Tent 308",
+    "brand": "Zenwave",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 142.93,
+    "rating": 4.4,
+    "reviews": 795,
+    "colors": [
+      "Volt",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "lightweight",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-488-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-488-zenwave/240/180",
+    "created_at": "2025-08-28",
+    "description": "Zenwave's Urban Tent 308 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1489",
+    "name": "Aero Sprint 196",
+    "brand": "PolarGrid",
+    "categories": [
+      "Shoes",
+      "Running"
+    ],
+    "price": 156.43,
+    "rating": 4.6,
+    "reviews": 1031,
+    "colors": [
+      "Navy"
+    ],
+    "sizes": [
+      "10",
+      "6",
+      "8"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "lightweight"
+    ],
+    "image_url": "https://picsum.photos/seed/shoes-running-489-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/shoes-running-489-polargrid/240/180",
+    "created_at": "2025-04-17",
+    "description": "The Aero Sprint 196 combines modern style with reliable performance in shoes gear."
+  },
+  {
+    "id": "sku_1490",
+    "name": "Atlas Crew 104",
+    "brand": "AuroraLab",
+    "categories": [
+      "Apparel",
+      "Tops"
+    ],
+    "price": 27.4,
+    "rating": 3.8,
+    "reviews": 77,
+    "colors": [
+      "Purple",
+      "Blue"
+    ],
+    "sizes": [
+      "XXL",
+      "M",
+      "S",
+      "L",
+      "XL",
+      "XS"
+    ],
+    "in_stock": true,
+    "tags": [
+      "new",
+      "best-seller",
+      "lightweight",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-tops-490-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-tops-490-auroralab/240/180",
+    "created_at": "2025-04-10",
+    "description": "Atlas Crew 104 from AuroraLab is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1491",
+    "name": "Trail Bottle 277",
+    "brand": "AuroraLab",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 13.78,
+    "rating": 4.9,
+    "reviews": 508,
+    "colors": [
+      "Blue",
+      "Forest"
+    ],
+    "sizes": [
+      "1L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "2025",
+      "eco",
+      "best-seller"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-491-auroralab/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-491-auroralab/240/180",
+    "created_at": "2025-04-24",
+    "description": "AuroraLab's Trail Bottle 277 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1492",
+    "name": "Stratus Shell 65",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Apparel",
+      "Outerwear"
+    ],
+    "price": 78.35,
+    "rating": 4.4,
+    "reviews": 1702,
+    "colors": [
+      "Navy",
+      "Red"
+    ],
+    "sizes": [
+      "XL",
+      "L",
+      "M"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/apparel-outerwear-492-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/apparel-outerwear-492-cloudbloc/240/180",
+    "created_at": "2024-12-20",
+    "description": "Stratus Shell 65 from Cloudbloc is a versatile apparel built for everyday use."
+  },
+  {
+    "id": "sku_1493",
+    "name": "Polar Lantern 296",
+    "brand": "Voltline",
+    "categories": [
+      "Outdoors",
+      "Camping"
+    ],
+    "price": 189.89,
+    "rating": 4.5,
+    "reviews": 556,
+    "colors": [
+      "White",
+      "Volt",
+      "Forest",
+      "Blue"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "2025",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/outdoors-camping-493-voltline/640/640",
+    "thumb_url": "https://picsum.photos/seed/outdoors-camping-493-voltline/240/180",
+    "created_at": "2025-04-23",
+    "description": "The Polar Lantern 296 combines modern style with reliable performance in outdoors gear."
+  },
+  {
+    "id": "sku_1494",
+    "name": "Echo Band 438",
+    "brand": "Cloudbloc",
+    "categories": [
+      "Electronics",
+      "Wearables"
+    ],
+    "price": 113.96,
+    "rating": 4.9,
+    "reviews": 614,
+    "colors": [
+      "Red",
+      "Gray"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "2025",
+      "water-resistant",
+      "eco"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-wearables-494-cloudbloc/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-wearables-494-cloudbloc/240/180",
+    "created_at": "2025-05-05",
+    "description": "Lightweight yet durable, the Echo Band 438 by Cloudbloc delivers outstanding quality for electronics enthusiasts."
+  },
+  {
+    "id": "sku_1495",
+    "name": "Atlas Kettle 171",
+    "brand": "PolarGrid",
+    "categories": [
+      "Home",
+      "Kitchen"
+    ],
+    "price": 29.0,
+    "rating": 4.2,
+    "reviews": 316,
+    "colors": [
+      "Black",
+      "Purple"
+    ],
+    "sizes": [],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "eco",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/home-kitchen-495-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/home-kitchen-495-polargrid/240/180",
+    "created_at": "2025-03-20",
+    "description": "Lightweight yet durable, the Atlas Kettle 171 by PolarGrid delivers outstanding quality for home enthusiasts."
+  },
+  {
+    "id": "sku_1496",
+    "name": "Atlas Flask 329",
+    "brand": "TrailForge",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 44.59,
+    "rating": 3.6,
+    "reviews": 1812,
+    "colors": [
+      "White"
+    ],
+    "sizes": [
+      "750ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "best-seller",
+      "water-resistant"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-496-trailforge/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-496-trailforge/240/180",
+    "created_at": "2024-12-02",
+    "description": "Lightweight yet durable, the Atlas Flask 329 by TrailForge delivers outstanding quality for accessories enthusiasts."
+  },
+  {
+    "id": "sku_1497",
+    "name": "Atlas Flask 357",
+    "brand": "Seoulistic",
+    "categories": [
+      "Accessories",
+      "Hydration"
+    ],
+    "price": 13.9,
+    "rating": 4.1,
+    "reviews": 868,
+    "colors": [
+      "Navy",
+      "Tan"
+    ],
+    "sizes": [
+      "500ml"
+    ],
+    "in_stock": true,
+    "tags": [
+      "lightweight",
+      "limited",
+      "best-seller",
+      "durable"
+    ],
+    "image_url": "https://picsum.photos/seed/accessories-hydration-497-seoulistic/640/640",
+    "thumb_url": "https://picsum.photos/seed/accessories-hydration-497-seoulistic/240/180",
+    "created_at": "2025-03-14",
+    "description": "The Atlas Flask 357 combines modern style with reliable performance in accessories gear."
+  },
+  {
+    "id": "sku_1498",
+    "name": "Glide Pack 131",
+    "brand": "PolarGrid",
+    "categories": [
+      "Bags",
+      "Backpacks"
+    ],
+    "price": 78.4,
+    "rating": 4.4,
+    "reviews": 1357,
+    "colors": [
+      "Black",
+      "White"
+    ],
+    "sizes": [
+      "18L"
+    ],
+    "in_stock": true,
+    "tags": [
+      "durable",
+      "new",
+      "2025"
+    ],
+    "image_url": "https://picsum.photos/seed/bags-backpacks-498-polargrid/640/640",
+    "thumb_url": "https://picsum.photos/seed/bags-backpacks-498-polargrid/240/180",
+    "created_at": "2025-03-25",
+    "description": "PolarGrid's Glide Pack 131 offers excellent value with thoughtful details and long‑lasting construction."
+  },
+  {
+    "id": "sku_1499",
+    "name": "Pulse Headphones 355",
+    "brand": "Zenwave",
+    "categories": [
+      "Electronics",
+      "Audio"
+    ],
+    "price": 140.82,
+    "rating": 5.0,
+    "reviews": 1348,
+    "colors": [
+      "Blue",
+      "Olive",
+      "Forest",
+      "White"
+    ],
+    "sizes": [],
+    "in_stock": false,
+    "tags": [
+      "water-resistant",
+      "2025",
+      "limited"
+    ],
+    "image_url": "https://picsum.photos/seed/electronics-audio-499-zenwave/640/640",
+    "thumb_url": "https://picsum.photos/seed/electronics-audio-499-zenwave/240/180",
+    "created_at": "2025-06-30",
+    "description": "Designed for comfort and durability, the Pulse Headphones 355 is perfect for electronics needs."
+  }
+]

--- a/examples/gcp/cb-searchbloc/main.tf
+++ b/examples/gcp/cb-searchbloc/main.tf
@@ -1,8 +1,9 @@
 module "searchbloc" {
   source = "../../../blocs/searchbloc"
 
-  namespace           = "obsbloc" # same namespace as obsbloc
-  app_name            = "searchbloc"
-  master_key          = var.master_key
-  storage_size        = "5Gi"
+  namespace         = "obsbloc" # same namespace as obsbloc
+  app_name          = "searchbloc"
+  storage_size      = "5Gi"
+  master_key        = var.master_key
+  public_search_key = var.public_search_key
 }


### PR DESCRIPTION
**Description**
This PR introduces a complete example for running **SearchBloc** with a realistic `products` dataset on GCP:

* **Examples**

  * Added `examples/gcp/cb-searchbloc` containing:

    * A step-by-step README for deploying SearchBloc on GKE and wiring a demo index.
    * `products_seed_500_clean.json` — sample dataset with 500 products.
    * Terraform example wiring `public_search_key` for the UI.
  * Provides curl snippets for key creation, index setup, seeding, and verification.

* **UI Updates**

  * Search bar placeholder updated from `logs` → `products` for clarity in demos.

* **Module / Infra**

  * Adjusted example module block in `main.tf` to include `public_search_key`.
  * Minor cleanup in `blocs/searchbloc/main.tf` lifecycle ignore list.

**Why**
Adds a ready-to-use dataset and documentation so users can quickly validate SearchBloc functionality in a realistic scenario (product search with filters/facets). This makes it easier to demo, test, and promote adoption.

**Notes**

* Uses shared LB/Cloud Armor if deployed alongside ObsBloc.
* Emphasizes best practices: never expose master key, prefer scoped public keys.

