### PR TITLE
release(appbloc): bump version to 0.3.0

### DIFF
--- a/blocs/appbloc/README.md
+++ b/blocs/appbloc/README.md
@@ -1,0 +1,161 @@
+# appbloc — GKE HTTPS app behind Global LB
+
+Deploy a containerized web app to **Google Kubernetes Engine** behind a **Global HTTP(S) Load Balancer** with a **Google ManagedCertificate**, automatic **HTTP→HTTPS redirect**, optional **Cloud Armor**, and **Cloud DNS** records. Production-minded defaults with minimal inputs.
+
+> Status: **v0.3.0 (Preview)** — solid for simple, stateless web apps.
+
+## Features
+
+* **Global HTTPS** via GCE Ingress + ManagedCertificate
+* **HTTP→HTTPS redirect** (FrontendConfig)
+* **Global static IP** (reused across deploys)
+* **Cloud DNS** A records (either **use existing zone** or **create a new one**)
+* **NEG** service with Autopilot drift ignores
+* **ENV vars** (non-secret) + checksum to trigger safe rollouts
+* **Probes & light resources** to keep Autopilot costs low
+* **Cloud Armor** attachable via annotation
+
+## Architecture
+
+```
+Internet → Global HTTP(S) LB → GCE Ingress (GCLB)
+            ├─ ManagedCertificate (TLS)
+            ├─ FrontendConfig (HTTP→HTTPS 301)
+            ├─ Cloud Armor (optional)
+            └─ Global Static IP
+                     │
+                     ▼
+                 Service (NEG)
+                     │
+                     ▼
+               Deployment (your image)
+```
+
+## Prereqs
+
+* A GKE cluster and `kubectl` context set.
+* Terraform providers: `google`, `kubernetes`. (Module also uses `kubernetes_manifest`.)
+* APIs: `compute.googleapis.com`, `container.googleapis.com`, `dns.googleapis.com`.
+
+## Quick start
+
+### Option A — Use an existing Cloud DNS zone (recommended)
+
+```hcl
+module "appbloc" {
+  source = "github.com/cloudbloc/cloudbloc//blocs/appbloc?ref=appbloc-0.3.0"
+
+  namespace      = "appbloc"
+  app_name       = "cloudbloc-webapp-prd"
+  image          = "nginx:stable-alpine"
+  container_port = 80
+  replicas       = 2
+
+  # Domains & IP
+  edge_ip_name   = "cloudbloc-edge-ip"
+  domains        = ["cloudbloc.io", "www.cloudbloc.io"]
+
+  # Use existing zone
+  create_dns_zone = false
+  dns_zone_name   = "cloudbloc-io"  # existing managed zone name
+
+  # Optional WAF
+  # cloudarmor_policy = "projects/<proj>/global/securityPolicies/<policy>"
+
+  # ENV (non-secrets)
+  env = { RUNTIME = "prod" }
+
+  # Demo HTML is OFF by default; enable only if you want it:
+  # enable_static_html = true
+  # html_path          = "${path.module}/examples/index.html"
+}
+```
+
+### Option B — Create a new Cloud DNS zone from your apex
+
+```hcl
+module "appbloc" {
+  source = "github.com/cloudbloc/cloudbloc//blocs/appbloc?ref=appbloc-0.3.0"
+
+  namespace        = "appbloc"
+  app_name         = "cloudbloc-webapp-prd"
+  image            = "nginx:stable-alpine"
+  container_port   = 80
+  edge_ip_name     = "cloudbloc-edge-ip"
+  domains          = ["example.com", "www.example.com"]
+
+  create_dns_zone  = true  # creates a managed zone from domains[0]
+}
+```
+
+Apply & verify:
+
+```bash
+terraform init
+terraform apply
+
+# Wait for certificate issuance (few minutes)
+kubectl -n appbloc describe managedcertificate
+
+# Redirect check
+curl -I http://cloudbloc.io | grep -i location  # → https://cloudbloc.io/...
+
+# HTTPS check
+curl -I https://cloudbloc.io
+```
+
+## Inputs
+
+| Name                        | Type         |          Default | Description                                                                 |
+| --------------------------- | ------------ | ---------------: | --------------------------------------------------------------------------- |
+| `namespace`                 | string       |                — | Target Kubernetes namespace.                                                |
+| `app_name`                  | string       |                — | Base name for Deployment/Service/Ingress.                                   |
+| `image`                     | string       | `"nginx:stable"` | Container image.                                                            |
+| `container_port`            | number       |                — | Port exposed by the container.                                              |
+| `replicas`                  | number       |              `2` | Desired replicas.                                                           |
+| `labels`                    | map(string)  |             `{}` | Extra labels for resources.                                                 |
+| `domains`                   | list(string) |                — | Domains for TLS & DNS records.                                              |
+| `edge_ip_name`              | string       |                — | Name of the global static IP to reserve/use.                                |
+| `cloudarmor_policy`         | string       |           `null` | Optional Cloud Armor policy to attach.                                      |
+| `extra_ingress_annotations` | map(string)  |             `{}` | Extra annotations to merge into the Ingress.                                |
+| `env`                       | map(string)  |             `{}` | Non-secret environment variables.                                           |
+| `enable_static_html`        | bool         |          `false` | If `true`, mount a demo HTML page to `/usr/share/nginx/html`.               |
+| `html_path`                 | string       |   `"index.html"` | Path to HTML file (used **only** when `enable_static_html = true`).         |
+| `create_dns_zone`           | bool         |          `false` | If `true`, create a Cloud DNS zone from `domains[0]`.                       |
+| `dns_zone_name`             | string       |           `null` | Name of an **existing** managed zone (used when `create_dns_zone = false`). |
+
+## Outputs
+
+| Name            | Description                                            |
+| --------------- | ------------------------------------------------------ |
+| `edge_ip_name`  | Global static IP resource name.                        |
+| `edge_ip_addr`  | Global static IP address.                              |
+| `dns_zone_name` | Active Cloud DNS zone name used (created or existing). |
+
+## Ops notes
+
+* **Redirect**: Ingress sets `allow-http = "true"` and points to a `FrontendConfig` that 301s to HTTPS.
+* **Certs**: ManagedCertificate covers all `domains`. First issuance may take several minutes.
+* **Rollouts**: Deployment includes `cloudbloc.io/env-checksum` to trigger a rollout when `env` changes.
+* **NEG**: Service enables NEGs and ignores `neg-status` to avoid Autopilot diffs.
+
+## Known limitations (v0.3.0 Preview)
+
+* Health probes point at `/`. If your app uses `/healthz` (etc.), adjust the probes or expose a `health_path` var.
+* Secrets/HPA are not included yet. Use native K8s Secrets or add an HPA as needed (planned in v0.3.x).
+
+## Tips
+
+* For zero-downtime single-replica rolls, consider:
+
+  ```hcl
+  strategy {
+    type = "RollingUpdate"
+    rolling_update { max_unavailable = 0, max_surge = "25%" }
+  }
+  ```
+* (Optional) Add an explicit Ingress dependency:
+
+  ```hcl
+  depends_on = [kubernetes_manifest.frontend_config]
+  ```

--- a/blocs/appbloc/outputs.tf
+++ b/blocs/appbloc/outputs.tf
@@ -9,6 +9,7 @@ output "edge_ip_addr" {
 }
 
 output "dns_zone_name" {
-  description = "Cloud DNS managed zone name"
-  value       = google_dns_managed_zone.zone.name
+  value       = local.zone_name
+  description = "Active Cloud DNS zone name"
 }
+

--- a/blocs/appbloc/variables.tf
+++ b/blocs/appbloc/variables.tf
@@ -29,12 +29,6 @@ variable "replicas" {
   default     = 2
 }
 
-variable "service_type" {
-  description = "Service type (LoadBalancer | ClusterIP | NodePort)"
-  type        = string
-  default     = "LoadBalancer"
-}
-
 variable "labels" {
   description = "Additional labels to add to resources"
   type        = map(string)
@@ -68,4 +62,28 @@ variable "extra_ingress_annotations" {
   description = "Additional annotations to merge into the Ingress"
   type        = map(string)
   default     = {}
+}
+
+variable "env" {
+  description = "Environment variables for the container (non-secret)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_static_html" {
+  description = "Mount a demo index.html from a ConfigMap at /usr/share/nginx/html"
+  type        = bool
+  default     = false
+}
+
+variable "create_dns_zone" {
+  description = "Create a Cloud DNS managed zone from the apex in var.domains[0]. If false, use dns_zone_name."
+  type        = bool
+  default     = false
+}
+
+variable "dns_zone_name" {
+  description = "Existing Cloud DNS zone name (ignored if create_dns_zone=true)"
+  type        = string
+  default     = null
 }

--- a/examples/gcp/cb-appbloc/README.md
+++ b/examples/gcp/cb-appbloc/README.md
@@ -1,0 +1,231 @@
+# `blocs/appbloc/examples/existing-dns/`
+
+> Use an **existing** Cloud DNS managed zone (recommended for most users).
+
+**versions.tf**
+
+```hcl
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    google = { source = "hashicorp/google",     version = ">= 5.0" }
+    kubernetes = { source = "hashicorp/kubernetes", version = ">= 2.25" }
+  }
+}
+```
+
+**providers.tf**
+
+```hcl
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_client_config" "default" {}
+
+data "google_container_cluster" "gke" {
+  project  = var.project_id
+  location = var.location   # use location here (zonal or regional)
+  name     = var.cluster_name
+}
+
+provider "kubernetes" {
+  host                   = "https://${data.google_container_cluster.gke.endpoint}"
+  cluster_ca_certificate = base64decode(data.google_container_cluster.gke.master_auth[0].cluster_ca_certificate)
+  token                  = data.google_client_config.default.access_token
+}
+```
+
+**variables.tf**
+
+```hcl
+variable "project_id"   { type = string }
+variable "region"       { type = string }               # e.g. "us-central1"
+variable "location"     { type = string }               # e.g. "us-central1-a" or "us-central1"
+variable "cluster_name" { type = string }
+
+variable "domains"      { type = list(string) }         # e.g. ["app.example.com","www.app.example.com"]
+variable "dns_zone_name" { type = string }              # existing zone name, e.g. "example-com"
+variable "edge_ip_name" { type = string }               # global static IP resource name
+
+variable "app_namespace" { type = string, default = "appbloc" }
+variable "app_image"     { type = string, default = "nginx:stable-alpine" }
+variable "app_port"      { type = number, default = 80 }
+variable "app_replicas"  { type = number, default = 2 }
+variable "environment"   { type = string, default = "prd" }
+
+variable "enable_static_html" { type = bool, default = false }
+variable "html_path"          { type = string, default = "index.html" }
+
+variable "cloudarmor_policy" {
+  type        = string
+  default     = null
+  description = "Optional: projects/<proj>/global/securityPolicies/<name>"
+}
+```
+
+**main.tf**
+
+```hcl
+locals {
+  env           = var.environment
+  html_abs_path = "${path.root}/static/${var.html_path}"
+}
+
+module "appbloc" {
+  source = "github.com/cloudbloc/cloudbloc//blocs/appbloc?ref=appbloc-0.3.0"
+
+  namespace            = var.app_namespace
+  app_name             = "cloudbloc-webapp-${var.environment}"
+
+  image                = var.app_image
+  replicas             = var.app_replicas
+  container_port       = var.app_port
+
+  domains              = var.domains
+  edge_ip_name         = var.edge_ip_name
+  cloudarmor_policy    = var.cloudarmor_policy
+
+  create_dns_zone      = false
+  dns_zone_name        = var.dns_zone_name
+
+  enable_static_html   = var.enable_static_html
+  html_path            = local.html_abs_path
+
+  labels = { env = local.env }
+}
+```
+
+**static/index.html**
+
+```html
+<!doctype html>
+<title>appbloc • existing-dns</title>
+<h1>✅ appbloc (existing-dns) is live</h1>
+<p>Served via GCLB + ManagedCertificate + HTTP→HTTPS redirect.</p>
+```
+
+---
+
+# 📁 `blocs/appbloc/examples/create-dns-zone/`
+
+> Create a **new** Cloud DNS managed zone from `domains[0]`.
+
+**versions.tf**
+
+```hcl
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    google = { source = "hashicorp/google",     version = ">= 5.0" }
+    kubernetes = { source = "hashicorp/kubernetes", version = ">= 2.25" }
+  }
+}
+```
+
+**providers.tf**
+
+```hcl
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_client_config" "default" {}
+
+data "google_container_cluster" "gke" {
+  project  = var.project_id
+  location = var.location
+  name     = var.cluster_name
+}
+
+provider "kubernetes" {
+  host                   = "https://${data.google_container_cluster.gke.endpoint}"
+  cluster_ca_certificate = base64decode(data.google_container_cluster.gke.master_auth[0].cluster_ca_certificate)
+  token                  = data.google_client_config.default.access_token
+}
+```
+
+**variables.tf**
+
+```hcl
+variable "project_id"   { type = string }
+variable "region"       { type = string }
+variable "location"     { type = string }
+variable "cluster_name" { type = string }
+
+variable "domains"      { type = list(string) }  # e.g. ["example.com", "www.example.com"]
+variable "edge_ip_name" { type = string }
+
+variable "app_namespace" { type = string, default = "appbloc" }
+variable "app_image"     { type = string, default = "nginx:stable-alpine" }
+variable "app_port"      { type = number, default = 80 }
+variable "app_replicas"  { type = number, default = 2 }
+variable "environment"   { type = string, default = "prd" }
+
+variable "enable_static_html" { type = bool, default = true }
+variable "html_path"          { type = string, default = "index.html" }
+
+variable "cloudarmor_policy" {
+  type        = string
+  default     = null
+  description = "Optional: projects/<proj>/global/securityPolicies/<name>"
+}
+```
+
+**main.tf**
+
+```hcl
+locals {
+  env           = var.environment
+  html_abs_path = "${path.root}/static/${var.html_path}"
+}
+
+module "appbloc" {
+  source = "github.com/cloudbloc/cloudbloc//blocs/appbloc?ref=appbloc-0.2.0"
+
+  namespace            = var.app_namespace
+  app_name             = "cloudbloc-webapp-${var.environment}"
+
+  image                = var.app_image
+  replicas             = var.app_replicas
+  container_port       = var.app_port
+
+  domains              = var.domains
+  edge_ip_name         = var.edge_ip_name
+  cloudarmor_policy    = var.cloudarmor_policy
+
+  create_dns_zone      = true
+
+  enable_static_html   = var.enable_static_html
+  html_path            = local.html_abs_path
+
+  labels = { env = local.env }
+}
+```
+
+**static/index.html**
+
+```html
+<!doctype html>
+<title>appbloc • create-dns-zone</title>
+<h1>🚀 appbloc (create-dns-zone) is live</h1>
+<p>This example created a new Cloud DNS zone from <code>domains[0]</code>.</p>
+```
+
+---
+
+## Run steps (both examples)
+
+```bash
+terraform init
+terraform apply
+
+# Wait a few minutes for the ManagedCertificate to be Active:
+kubectl -n appbloc describe managedcertificate
+
+# Check redirect and TLS
+curl -I http://<your-domain>  | grep -i location
+curl -I https://<your-domain>
+```

--- a/examples/gcp/cb-appbloc/main.tf
+++ b/examples/gcp/cb-appbloc/main.tf
@@ -6,14 +6,20 @@ locals {
 module "appbloc" {
   source         = "../../../blocs/appbloc"
   namespace      = var.app_namespace
-  edge_ip_name   = var.edge_ip_name
   app_name       = "cloudbloc-webapp-${var.environment}"
+
   image          = var.app_image
-  container_port = var.app_port
   replicas       = var.app_replicas
-  service_type   = var.service_type
+  container_port = var.app_port
   domains        = var.domains
   html_path      = local.html_abs_path
-  labels         = { env = local.env }
+  enable_static_html = true
+
+  labels         = {
+    env = local.env
+    }
+
+  edge_ip_name   = var.edge_ip_name
   cloudarmor_policy = var.security_policy_name
+  create_dns_zone = true
 }

--- a/examples/gcp/cb-appbloc/variables.tf
+++ b/examples/gcp/cb-appbloc/variables.tf
@@ -57,12 +57,6 @@ variable "app_replicas" {
   default     = 1
 }
 
-variable "service_type" {
-  description = "Kubernetes Service type (LoadBalancer | ClusterIP | NodePort)"
-  type        = string
-  default     = "LoadBalancer"
-}
-
 variable "domains" {
   type    = list(string)
   default = ["cloudbloc.io", "www.cloudbloc.io"]


### PR DESCRIPTION
## Changes
- Add `create_dns_zone` and `dns_zone_name` variables to support either
  creating a new Cloud DNS zone or reusing an existing one.
- Add `enable_static_html` flag to optionally mount a demo HTML ConfigMap
  (disabled by default).
- Update examples (`existing-dns/` and `create-dns-zone/`) to demonstrate
  both DNS modes.
- Refresh README with new inputs and behavior.

## Breaking change
- DNS zone is no longer always created.
- Users must set `create_dns_zone = true` to create a new zone,
  or pass `dns_zone_name` to reuse an existing one.
