### PR TITLE
chore(license): update copyright owner to Cloudbloc

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 Cloudbloc
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What
- Updated LICENSE file to replace placeholder copyright line with:
  `Copyright 2025 Cloudbloc`

## Why
- Clarifies project ownership under the Cloudbloc name
- Improves professionalism for external users and legal teams
- Aligns with Apache-2.0 best practices

## How
- Replaced `[yyyy] [name of copyright owner]` with `2025 Cloudbloc`

## Testing
- [x] LICENSE renders correctly
- [x] No functional code changes
