### PR TITLE
docs: update bloc usage sources and screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,38 @@
 ## ⚡ SaaS-as-Code
 **One Terraform module (bloc) = One SaaS replacement.**
 
-**Cloudbloc** is the next step after *IaaS, IaC, and SaaS.*
-
 👉 **SaaS-as-Code**: opinionated Terraform + Kubernetes modules that let you replace overpriced SaaS with **self-hosted building blocks on your Cloud.**
 
-💡 With Cloudbloc, you don’t stitch together infra — you drop in **one module** and get a **complete SaaS replacement** running in your cluster.
+💡 With Cloudbloc, you don’t stitch together infra. You drop in **one module** and get a **core SaaS replacement** running in your cluster.
 Just set a few variables → production-ready stack. No YAML sprawl. No manual plumbing.
+
+> 🔓 **Everything in this repository is open source and will remain free forever.**
+
+---
+
+## 🌐 Live Demos
+
+| Bloc          | Live URL                                              | Replacement        |
+|---------------|-------------------------------------------------------|--------------------|
+| 🚀 **AppBloc**   | [cloudbloc.io](https://cloudbloc.io)                     | Heroku Core             |
+| 📊 **ObsBloc**   | [obsbloc.cloudbloc.io](https://obsbloc.cloudbloc.io)     | Datadog Core            |
+| 🔍 **SearchBloc**| [searchbloc.cloudbloc.io](https://searchbloc.cloudbloc.io) | Elasticsearch/Algolia Core |
+
+---
+### 📸 Screenshots
+
+**🚀 AppBloc**
+<img src="./screenshots/appbloc_demo.png" alt="AppBloc Demo" width="800"/>
+
+**📊 ObsBloc**
+<img src="./screenshots/obsbloc_demo.png" alt="ObsBloc Demo" width="800"/>
+
+**🔍 SearchBloc**
+<img src="./screenshots/searchbloc_demo.png" alt="SearchBloc Demo" width="800"/>
+
+---
+
+**Cloudbloc** is the next step after *IaaS, IaC, and SaaS.*
 
 🔧 **How it works:**
 Each bloc is a pre-packaged Terraform module that wires up the right cloud + Kubernetes resources for you. **Minimal infra work, maximum leverage.**
@@ -96,7 +122,7 @@ Release automation: **release-please (manifest mode)** with per-bloc tagging (e.
 
 ```hcl
 module "appbloc" {
-  source = "github.com/cloudbloc/cloudbloc//blocs/appbloc?ref=appbloc-v0.4.1"
+  source = "github.com/cloudbloc/cloudbloc//blocs/appbloc?ref=appbloc-0.4.2"
 
   namespace      = var.app_namespace
   app_name       = "cloudbloc-webapp-${var.environment}"
@@ -126,7 +152,7 @@ module "appbloc" {
 
 ```hcl
 module "obsbloc" {
-  source = "github.com/cloudbloc/cloudbloc//blocs/obsbloc?ref=obsbloc-v0.4.1"
+  source = "github.com/cloudbloc/cloudbloc//blocs/obsbloc?ref=obsbloc-0.4.2"
 
   namespace    = var.namespace
   app_name     = var.app_name
@@ -157,7 +183,7 @@ module "obsbloc" {
 
 ```hcl
 module "searchbloc" {
-  source = "github.com/cloudbloc/cloudbloc//blocs/searchbloc?ref=searchbloc-v0.4.1"
+  source = "github.com/cloudbloc/cloudbloc//blocs/searchbloc?ref=searchbloc-0.4.2"
 
   project_id        = var.project_id
   namespace         = "obsbloc"

--- a/examples/gcp/cb-appbloc/main.tf
+++ b/examples/gcp/cb-appbloc/main.tf
@@ -4,7 +4,8 @@ locals {
 }
 
 module "appbloc" {
-  source         = "../../../blocs/appbloc"
+  source = "github.com/cloudbloc/cloudbloc//blocs/appbloc?ref=appbloc-0.4.2"
+  # source         = "../../../blocs/appbloc"
   namespace      = var.app_namespace
   app_name       = "cloudbloc-webapp-${var.environment}"
 

--- a/examples/gcp/cb-appbloc/static/index.html
+++ b/examples/gcp/cb-appbloc/static/index.html
@@ -493,7 +493,7 @@
             </p>
             <p><a class="bloc-link" href="https://cloudbloc.io" target="_blank" rel="noopener">cloudbloc.io →</a></p>
             <pre class="bloc-code"><code>module "appbloc" {
-      source   = "github.com/cloudbloc/cloudbloc//blocs/appbloc?ref=appbloc-v0.4.1"
+      source   = "github.com/cloudbloc/cloudbloc//blocs/appbloc?ref=appbloc-0.4.2"
       app_name = "cloudbloc-webapp-${var.environment}"
       image    = var.app_image
       domains  = var.domains
@@ -512,7 +512,7 @@
             </p>
             <p><a class="bloc-link" href="https://obsbloc.cloudbloc.io" target="_blank" rel="noopener">obsbloc.cloudbloc.io →</a></p>
             <pre class="bloc-code"><code>module "obsbloc" {
-      source        = "github.com/cloudbloc/cloudbloc//blocs/obsbloc?ref=obsbloc-v0.4.1"
+      source        = "github.com/cloudbloc/cloudbloc//blocs/obsbloc?ref=obsbloc-0.4.1"
       namespace     = var.namespace
       domains       = var.domains
       edge_ip_name  = var.edge_ip_name
@@ -531,7 +531,7 @@
             </p>
             <p><a class="bloc-link" href="https://searchbloc.cloudbloc.io" target="_blank" rel="noopener">searchbloc.cloudbloc.io →</a></p>
             <pre class="bloc-code"><code>module "searchbloc" {
-      source     = "github.com/cloudbloc/cloudbloc//blocs/searchbloc?ref=searchbloc-v0.4.1"
+      source     = "github.com/cloudbloc/cloudbloc//blocs/searchbloc?ref=searchbloc-0.4.2"
       project_id = var.project_id
       namespace  = "obsbloc"
       app_name   = "searchbloc"
@@ -849,7 +849,7 @@
     }
 
     module "appbloc" {
-        source   = "github.com/cloudbloc/cloudbloc//blocs/appbloc?ref=appbloc-v0.4.1"
+        source   = "github.com/cloudbloc/cloudbloc//blocs/appbloc?ref=appbloc-0.4.2"
         app_name = "cloudbloc-webapp-${var.environment}"
         image    = var.app_image
         domains  = var.domains

--- a/examples/gcp/cb-obsbloc/main.tf
+++ b/examples/gcp/cb-obsbloc/main.tf
@@ -1,5 +1,6 @@
 module "obsbloc" {
-  source       = "../../../blocs/obsbloc"
+  source = "github.com/cloudbloc/cloudbloc//blocs/obsbloc?ref=obsbloc-0.4.2"
+  # source       = "../../../blocs/obsbloc"
   namespace    = var.namespace
   app_name     = var.app_name
   edge_ip_name = var.edge_ip_name

--- a/examples/gcp/cb-searchbloc/main.tf
+++ b/examples/gcp/cb-searchbloc/main.tf
@@ -1,5 +1,6 @@
 module "searchbloc" {
-  source = "../../../blocs/searchbloc"
+  source = "github.com/cloudbloc/cloudbloc//blocs/searchbloc?ref=searchbloc-0.4.2"
+  # source = "../../../blocs/searchbloc"
 
   project_id        = var.project_id
   namespace         = "obsbloc" # same namespace as obsbloc


### PR DESCRIPTION
## What

* Updated README and example usage to point to GitHub module sources with versioned refs (`0.4.2`).
* Adjusted wording (“core SaaS replacement”) for clarity.
* Added live demo URLs and screenshots for AppBloc, ObsBloc, and SearchBloc.

## Why

* Ensure users can copy-paste working module sources directly from README/examples.
* Clarify positioning of blocs as core SaaS replacements, not full platforms.
* Provide visual demos for better onboarding and trust.

## How

* Replaced local `../../../blocs/...` sources with `github.com/cloudbloc/cloudbloc//blocs/...` refs.
* Bumped module refs from `v0.4.1` → `0.4.2`.
* Added screenshots under `/screenshots`.
* Minor copy tweaks in README and HTML examples.

## Testing

* [x] Verified module sources resolve to correct tags.
* [x] Rendered screenshots locally.

