### PR TITLE
feat(edge): add AppBloc worker CronJob and enhance DropBloc cron scanning

### DIFF
--- a/blocs/edge/appbloc/README.md
+++ b/blocs/edge/appbloc/README.md
@@ -118,6 +118,18 @@ module "appbloc" {
 }
 ```
 
+### Worker security context
+
+Lock down the optional worker CronJob by specifying user/group IDs:
+
+```hcl
+worker_security_context = {
+  runAsUser  = 33
+  runAsGroup = 33
+  fsGroup    = 33
+}
+```
+
 ---
 
 # 🌐 Setting Up Cloudflare Tunnel (One-Time)

--- a/blocs/edge/appbloc/main.tf
+++ b/blocs/edge/appbloc/main.tf
@@ -211,6 +211,14 @@ resource "kubernetes_cron_job_v1" "worker" {
               command = var.worker_command
               args    = var.worker_args
 
+              dynamic "security_context" {
+                for_each = var.worker_security_context != null ? [var.worker_security_context] : []
+                content {
+                  run_as_user  = security_context.value.runAsUser
+                  run_as_group = security_context.value.runAsGroup
+                }
+              }
+
               resources {
                 requests = {
                   cpu    = var.worker_requests_cpu
@@ -225,6 +233,13 @@ resource "kubernetes_cron_job_v1" "worker" {
 
 
             restart_policy = var.worker_restart_policy
+
+            dynamic "security_context" {
+              for_each = var.worker_security_context != null ? [var.worker_security_context] : []
+              content {
+                fs_group = security_context.value.fsGroup
+              }
+            }
 
             dynamic "image_pull_secrets" {
               for_each = var.worker_image_pull_secret != null ? [1] : []

--- a/blocs/edge/appbloc/main.tf
+++ b/blocs/edge/appbloc/main.tf
@@ -1,6 +1,9 @@
 locals {
   # still useful for rolling pods on env change
   env_checksum = sha256(jsonencode(var.env))
+
+  # If worker_env is empty, inherit env from web container
+  worker_env = length(var.worker_env) > 0 ? var.worker_env : var.env
 }
 
 resource "kubernetes_namespace_v1" "namespace" {
@@ -104,6 +107,13 @@ resource "kubernetes_deployment_v1" "app" {
           }
         }
 
+        dynamic "image_pull_secrets" {
+          for_each = var.worker_image_pull_secret != null ? [1] : []
+          content {
+            name = var.worker_image_pull_secret
+          }
+        }
+
         dynamic "volume" {
           for_each = var.enable_static_html ? [kubernetes_config_map_v1.web_html[0].metadata[0].name] : []
           content {
@@ -111,6 +121,141 @@ resource "kubernetes_deployment_v1" "app" {
 
             config_map {
               name = volume.value
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+########################################
+# NEW: Optional YouTube automation worker (CronJob)
+########################################
+
+resource "kubernetes_cron_job_v1" "worker" {
+  count = var.enable_worker ? 1 : 0
+
+  metadata {
+    name      = "${var.app_name}-worker"
+    namespace = kubernetes_namespace_v1.namespace.metadata[0].name
+    labels    = merge({ app = "${var.app_name}-worker" }, var.labels)
+  }
+
+  spec {
+    schedule                      = var.worker_schedule
+    concurrency_policy            = var.worker_concurrency_policy
+    successful_jobs_history_limit = var.worker_successful_jobs_history_limit
+    failed_jobs_history_limit     = var.worker_failed_jobs_history_limit
+
+    job_template {
+      metadata {
+        labels = merge({ app = "${var.app_name}-worker" }, var.labels)
+      }
+
+      spec {
+        backoff_limit = var.worker_backoff_limit
+
+        template {
+          metadata {
+            labels = merge({ app = "${var.app_name}-worker" }, var.labels)
+          }
+
+          spec {
+            container {
+              name = "worker"
+              # If worker_image is "", reuse the main image
+              image = var.worker_image != "" ? var.worker_image : var.image
+
+              dynamic "env" {
+                for_each = local.worker_env
+                content {
+                  name  = env.key
+                  value = env.value
+                }
+              }
+
+              dynamic "env" {
+                for_each = var.worker_env_from_secret
+                content {
+                  name = env.key
+                  value_from {
+                    secret_key_ref {
+                      name = env.value
+                      key  = env.key
+                    }
+                  }
+                }
+              }
+
+              # Optional hostPath mounts for /input and /output
+              dynamic "volume_mount" {
+                for_each = var.worker_input_host_path != null ? [1] : []
+                content {
+                  name       = "worker-input"
+                  mount_path = "/input"
+                  read_only  = false
+                }
+              }
+
+              dynamic "volume_mount" {
+                for_each = var.worker_output_host_path != null ? [1] : []
+                content {
+                  name       = "worker-output"
+                  mount_path = "/output"
+                  read_only  = false
+                }
+              }
+
+              # command/args are attributes, not blocks
+              command = var.worker_command
+              args    = var.worker_args
+
+              resources {
+                requests = {
+                  cpu    = var.worker_requests_cpu
+                  memory = var.worker_requests_memory
+                }
+                limits = {
+                  cpu    = var.worker_limits_cpu
+                  memory = var.worker_limits_memory
+                }
+              }
+            }
+
+
+            restart_policy = var.worker_restart_policy
+
+            dynamic "image_pull_secrets" {
+              for_each = var.worker_image_pull_secret != null ? [1] : []
+              content {
+                name = var.worker_image_pull_secret
+              }
+            }
+
+            # Optional hostPath volumes backing /input and /output
+            dynamic "volume" {
+              for_each = var.worker_input_host_path != null ? [1] : []
+              content {
+                name = "worker-input"
+
+                host_path {
+                  path = var.worker_input_host_path
+                  type = "DirectoryOrCreate"
+                }
+              }
+            }
+
+            dynamic "volume" {
+              for_each = var.worker_output_host_path != null ? [1] : []
+              content {
+                name = "worker-output"
+
+                host_path {
+                  path = var.worker_output_host_path
+                  type = "DirectoryOrCreate"
+                }
+              }
             }
           }
         }
@@ -267,5 +412,3 @@ resource "kubernetes_deployment_v1" "cloudflared" {
     }
   }
 }
-
-

--- a/blocs/edge/appbloc/main.tf
+++ b/blocs/edge/appbloc/main.tf
@@ -130,7 +130,7 @@ resource "kubernetes_deployment_v1" "app" {
 }
 
 ########################################
-# NEW: Optional YouTube automation worker (CronJob)
+# NEW: Optional automation worker (CronJob)
 ########################################
 
 resource "kubernetes_cron_job_v1" "worker" {

--- a/blocs/edge/appbloc/variables.tf
+++ b/blocs/edge/appbloc/variables.tf
@@ -210,3 +210,13 @@ variable "worker_limits_memory" {
   type        = string
   default     = "512Mi"
 }
+
+variable "worker_security_context" {
+  description = "Optional security context for the worker CronJob pod/container (UID/GID/fsGroup)."
+  type = object({
+    runAsUser  = optional(number)
+    runAsGroup = optional(number)
+    fsGroup    = optional(number)
+  })
+  default = null
+}

--- a/blocs/edge/appbloc/variables.tf
+++ b/blocs/edge/appbloc/variables.tf
@@ -1,3 +1,6 @@
+##########
+# Core app variables
+##########
 
 variable "namespace" {
   description = "Kubernetes namespace to deploy the app into"
@@ -61,6 +64,10 @@ variable "node_port" {
   default     = 30081
 }
 
+##########
+# Cloudflare tunnel variables
+##########
+
 variable "enable_cloudflared" {
   description = "Deploy an in-cluster Cloudflare tunnel for this app"
   type        = bool
@@ -84,4 +91,122 @@ variable "cloudflared_credentials_json" {
   type        = string
   sensitive   = true
   default     = null
+}
+
+##########
+# Worker / CronJob variables
+##########
+
+variable "enable_worker" {
+  description = "Enable a worker CronJob for background/automation tasks"
+  type        = bool
+  default     = false
+}
+
+variable "worker_image" {
+  description = "Container image for the worker (defaults to web image if empty)"
+  type        = string
+  default     = ""
+}
+
+variable "worker_schedule" {
+  description = "Cron schedule for the worker (e.g. \"*/5 * * * *\" for every 5 minutes)"
+  type        = string
+  default     = "0 * * * *" # every hour by default
+}
+
+variable "worker_command" {
+  description = "Optional command for the worker container"
+  type        = list(string)
+  default     = []
+}
+
+variable "worker_args" {
+  description = "Optional args for the worker container"
+  type        = list(string)
+  default     = []
+}
+
+variable "worker_env" {
+  description = "Environment variables for the worker. If empty, inherits env from the web app."
+  type        = map(string)
+  default     = {}
+}
+
+variable "worker_input_host_path" {
+  description = "Optional hostPath on the node to mount at /input in the worker container."
+  type        = string
+  default     = null
+}
+
+variable "worker_output_host_path" {
+  description = "Optional hostPath on the node to mount at /output in the worker container."
+  type        = string
+  default     = null
+}
+
+variable "worker_env_from_secret" {
+  description = "Map of ENV_VAR_NAME -> secret name. Secret key must match the env var name."
+  type        = map(string)
+  default     = {}
+}
+
+variable "worker_image_pull_secret" {
+  description = "Optional imagePullSecret name for pulling private images."
+  type        = string
+  default     = null
+}
+
+variable "worker_restart_policy" {
+  description = "Pod restart policy for the worker job"
+  type        = string
+  default     = "OnFailure"
+}
+
+variable "worker_backoff_limit" {
+  description = "How many times Kubernetes should retry a failed job"
+  type        = number
+  default     = 3
+}
+
+variable "worker_concurrency_policy" {
+  description = "Concurrency policy for the CronJob: Allow, Forbid, or Replace"
+  type        = string
+  default     = "Forbid"
+}
+
+variable "worker_successful_jobs_history_limit" {
+  description = "How many successful jobs to keep"
+  type        = number
+  default     = 1
+}
+
+variable "worker_failed_jobs_history_limit" {
+  description = "How many failed jobs to keep"
+  type        = number
+  default     = 3
+}
+
+variable "worker_requests_cpu" {
+  description = "CPU requests for worker container"
+  type        = string
+  default     = "100m"
+}
+
+variable "worker_requests_memory" {
+  description = "Memory requests for worker container"
+  type        = string
+  default     = "256Mi"
+}
+
+variable "worker_limits_cpu" {
+  description = "CPU limits for worker container"
+  type        = string
+  default     = "500m"
+}
+
+variable "worker_limits_memory" {
+  description = "Memory limits for worker container"
+  type        = string
+  default     = "512Mi"
 }

--- a/blocs/edge/dropbloc/README.md
+++ b/blocs/edge/dropbloc/README.md
@@ -153,7 +153,23 @@ After apply:
 
 ---
 
-# 🛠️ **4. Outputs**
+# ⏱ **4. Nextcloud Cron Runner**
+
+Nextcloud’s `backgroundjobs_mode = cron` requires `cron.php` to run frequently or file metadata (like uploads created by other pods) will fall behind. Dropbloc enables the Helm chart’s built-in CronJob (`nextcloud-cron`) so Kubernetes handles `php -f /var/www/html/cron.php -- --verbose` every 5 minutes by default using the same image as the primary app.
+
+* Tune how often it runs using `nextcloud_cron_schedule`.
+
+After applying Terraform you can confirm it’s running:
+
+```bash
+kubectl -n dropbloc get cronjob nextcloud-cron
+kubectl -n dropbloc get jobs --sort-by=.metadata.creationTimestamp | tail -n 5
+kubectl -n dropbloc logs job/<latest-nextcloud-cron-job>
+```
+
+---
+
+# 🛠️ **5. Outputs**
 
 After `apply`, Terraform prints:
 
@@ -164,7 +180,7 @@ nextcloud_public_url = cloud.mydomain.com
 
 ---
 
-# 🧪 **5. Tips & Best Practices**
+# 🧪 **6. Tips & Best Practices**
 
 ### Storage
 

--- a/blocs/edge/dropbloc/variables.tf
+++ b/blocs/edge/dropbloc/variables.tf
@@ -129,3 +129,9 @@ variable "nextcloud_cron_schedule" {
   type        = string
   default     = "*/5 * * * *"
 }
+
+variable "nextcloud_files_scan_paths" {
+  description = "Optional list of Nextcloud data paths to rescan after cron.php completes."
+  type        = list(string)
+  default     = []
+}

--- a/blocs/edge/dropbloc/variables.tf
+++ b/blocs/edge/dropbloc/variables.tf
@@ -106,3 +106,26 @@ variable "nextcloud_canonical_protocol" {
   default     = "https"
 }
 
+variable "nextcloud_image_registry" {
+  type        = string
+  description = "Container registry hosting the Nextcloud image."
+  default     = "docker.io"
+}
+
+variable "nextcloud_image_repository" {
+  type        = string
+  description = "Repository for the Nextcloud image (without registry)."
+  default     = "library/nextcloud"
+}
+
+variable "nextcloud_image_tag" {
+  type        = string
+  description = "Tag for the Nextcloud container image (defaults to the Helm chart's appVersion + flavor)."
+  default     = "32.0.2-apache"
+}
+
+variable "nextcloud_cron_schedule" {
+  description = "Cron schedule for running Nextcloud cron.php."
+  type        = string
+  default     = "*/5 * * * *"
+}

--- a/examples/edge/appbloc/main.tf
+++ b/examples/edge/appbloc/main.tf
@@ -4,8 +4,8 @@ locals {
 }
 
 module "appbloc" {
-  source = "github.com/cloudbloc/cloudbloc//blocs/edge/appbloc?ref=edge-appbloc-v0.1.0"
-  # source = "../../../blocs/edge/appbloc"
+  # source = "github.com/cloudbloc/cloudbloc//blocs/edge/appbloc?ref=edge-appbloc-v0.1.0"
+  source = "../../../blocs/edge/appbloc"
 
   namespace      = var.app_namespace
   app_name       = "cloudbloc-webapp-${var.environment}"

--- a/examples/edge/dropbloc/main.tf
+++ b/examples/edge/dropbloc/main.tf
@@ -1,6 +1,6 @@
 module "dropbloc" {
-  source = "github.com/cloudbloc/cloudbloc//blocs/edge/dropbloc?ref=edge-dropbloc-v0.2.0"
-  # source = "../../../blocs/edge/dropbloc"
+  # source = "github.com/cloudbloc/cloudbloc//blocs/edge/dropbloc?ref=edge-dropbloc-v0.2.0"
+  source = "../../../blocs/edge/dropbloc"
 
   namespace      = "dropbloc"
   node_ip        = "10.0.0.187" # LAN IP
@@ -21,4 +21,6 @@ module "dropbloc" {
   enable_cloudflared           = true
   cloudflared_credentials_file = abspath("${path.module}/credentials.json")
   cloudflared_tunnel_id        = "26b4d1ec-384f-477e-a404-f3d7352b45db"
+
+  nextcloud_cron_schedule = "*/5 * * * *"
 }

--- a/examples/edge/dropbloc/main.tf
+++ b/examples/edge/dropbloc/main.tf
@@ -22,5 +22,10 @@ module "dropbloc" {
   cloudflared_credentials_file = abspath("${path.module}/credentials.json")
   cloudflared_tunnel_id        = "26b4d1ec-384f-477e-a404-f3d7352b45db"
 
+  nextcloud_files_scan_paths = [
+    "yprk/files/yt",
+    "donggu/files/yt",
+  ]
+
   nextcloud_cron_schedule = "*/5 * * * *"
 }


### PR DESCRIPTION
## What
- Added an optional AppBloc worker CronJob (`enable_worker`) for background/automation tasks.
- Added worker security context support (`runAsUser` / `runAsGroup` / `fsGroup`) to lock down the worker pod/container.
- Updated DropBloc to:
  - enable and configure the Nextcloud Helm chart CronJob (`cron.php`) via Terraform values
  - optionally run `occ files:scan` for configured paths after `cron.php`
  - set `helm_release.wait = true` for more predictable applies
- Updated READMEs and examples to document the new worker and cron options.

## Why
- Need a simple, repeatable way to run background automation (e.g. ingestion, subtitle jobs, batch tasks) alongside AppBloc without introducing another always-on deployment.
- Nextcloud `backgroundjobs_mode=cron` requires `cron.php` to run frequently; optional file scans help keep metadata in sync for paths written or updated by automation.

## How
### AppBloc
- Introduced `kubernetes_cron_job_v1.worker`, gated by `enable_worker`.
- Worker container supports:
  - `worker_image` (defaults to the main app image if empty)
  - `worker_command` / `worker_args`
  - env inheritance: `worker_env` falls back to main `env` if empty
  - secret-based env via `worker_env_from_secret` (`ENV_VAR_NAME -> secret name`; secret key must match env var name)
  - optional `/input` and `/output` hostPath mounts
  - optional `worker_image_pull_secret`
  - optional `worker_security_context` (container `runAs*`, pod `fsGroup`)

### DropBloc
- Enabled the chart’s `nextcloud-cron` and configured the schedule via `nextcloud_cron_schedule`.
- Appended optional `occ files:scan --path=...` commands via `nextcloud_files_scan_paths`.
- Migrated Cloudflared resources to `_v1` types for consistency (`kubernetes_secret_v1`, `kubernetes_config_map_v1`) and updated references.
