### PR TITLE
docs: add restore reproducibility checklists

### DIFF
--- a/APPBLOC_RESTORE.md
+++ b/APPBLOC_RESTORE.md
@@ -1,0 +1,307 @@
+# AppBloc Restore Requirements
+
+This document records exactly what is needed to reproduce the Edge AppBloc deployment from this repository.
+
+Current checkout status:
+
+- Branch `main` was pulled and was already up to date.
+- No local Terraform state directory or state file was found under `examples/edge/appbloc`.
+- `examples/edge/appbloc/credentials.json` is missing in this checkout.
+- `/home/yprk/.kube/edge` is missing on this machine.
+- Because the kubeconfig and Terraform state access are not present locally, this document is repo-derived. It does not prove what is currently live on the Tiny.
+
+## Terraform Entry Point
+
+Use this Terraform root:
+
+```bash
+examples/edge/appbloc
+```
+
+Backend:
+
+```hcl
+terraform {
+  backend "gcs" {
+    prefix = "edge-appbloc"
+  }
+}
+```
+
+Backend config:
+
+```hcl
+bucket = "cloudbloc-tfstate-prd"
+```
+
+Provider config:
+
+```hcl
+provider "kubernetes" {
+  config_path = "~/.kube/edge"
+}
+
+provider "helm" {
+  kubernetes = {
+    config_path = "~/.kube/edge"
+  }
+}
+```
+
+## Exact Committed AppBloc Inputs
+
+These values come from `examples/edge/appbloc/main.tf` and `examples/edge/appbloc/variables.tf`.
+
+Defaults:
+
+```hcl
+environment   = "prd"
+app_namespace = "appbloc"
+app_image     = "nginx:stable"
+app_port      = 80
+app_replicas  = 1
+html_path     = "index.html"
+node_port     = 30081
+domains       = ["cloudbloc.io", "www.cloudbloc.io"]
+```
+
+Computed locals:
+
+```hcl
+env           = var.environment
+html_abs_path = "${path.root}/static/${var.html_path}"
+```
+
+Effective module inputs:
+
+```hcl
+namespace      = "appbloc"
+app_name       = "cloudbloc-webapp-prd"
+image          = "nginx:stable"
+container_port = 80
+replicas       = 1
+
+labels = {
+  env = "prd"
+}
+
+enable_static_html = true
+html_path          = "${path.root}/static/index.html"
+
+node_port = 30081
+
+enable_cloudflared           = true
+cloudflared_tunnel_id        = "109c1cc5-0788-4761-bbe6-06cfd05c769f"
+cloudflared_hostname         = "cloudbloc.io"
+cloudflared_credentials_json = file("${path.module}/credentials.json")
+```
+
+Module source:
+
+```hcl
+source = "../../../blocs/edge/appbloc"
+```
+
+The committed static HTML file is:
+
+```bash
+examples/edge/appbloc/static/index.html
+```
+
+## Resources Terraform Creates
+
+The Edge AppBloc module creates:
+
+- Kubernetes namespace: `appbloc`.
+- Optional ConfigMap `web-html` containing `index.html`.
+- Kubernetes Deployment: `cloudbloc-webapp-prd`.
+- Kubernetes NodePort Service: `cloudbloc-webapp-prd-svc`.
+- NodePort: `30081`.
+- Optional worker CronJob if `enable_worker = true`; the current example does not enable it.
+- Optional Cloudflare tunnel resources because `enable_cloudflared = true`:
+  - Secret `cloudflared-credentials`.
+  - ConfigMap `cloudflared-config`.
+  - Deployment `cloudflared`.
+
+The `cloudflared` config routes:
+
+- `cloudbloc.io` to the AppBloc service.
+- `www.cloudbloc.io` to the AppBloc service.
+- all other requests to `http_status:404`.
+
+## Required Host State On The Tiny
+
+The Tiny must have:
+
+- Kubernetes installed and running.
+- A kubeconfig for the cluster copied to the Terraform runner at `~/.kube/edge`.
+- A node reachable on the LAN for NodePort traffic.
+- NodePort `30081` available.
+- Outbound internet access to pull:
+  - `nginx:stable`.
+  - `cloudflare/cloudflared:latest`.
+
+Unlike DropBloc, AppBloc does not require a persistent hostPath data directory for the current example.
+
+## Required Local Files
+
+The machine running Terraform needs:
+
+```bash
+~/.kube/edge
+examples/edge/appbloc/credentials.json
+examples/edge/appbloc/static/index.html
+```
+
+Current local check:
+
+- `~/.kube/edge`: missing.
+- `examples/edge/appbloc/credentials.json`: missing.
+- `examples/edge/appbloc/static/index.html`: present and committed.
+
+`credentials.json` is intentionally ignored by git:
+
+```gitignore
+examples/edge/appbloc/credentials.json
+```
+
+## Required External State
+
+### Terraform State
+
+Terraform expects remote state in:
+
+```text
+gs://cloudbloc-tfstate-prd/edge-appbloc
+```
+
+To reproduce from existing state, the runner needs GCP auth with read/write access to the `cloudbloc-tfstate-prd` bucket.
+
+To reproduce from scratch, the bucket must exist before `terraform init`.
+
+### Cloudflare Tunnel
+
+The committed tunnel ID is:
+
+```text
+109c1cc5-0788-4761-bbe6-06cfd05c769f
+```
+
+The public hostnames are:
+
+```text
+cloudbloc.io
+www.cloudbloc.io
+```
+
+To reproduce exactly, Cloudflare must contain:
+
+- A tunnel with ID `109c1cc5-0788-4761-bbe6-06cfd05c769f`.
+- DNS routes for `cloudbloc.io` and `www.cloudbloc.io` to that tunnel.
+- The matching tunnel credentials JSON at `examples/edge/appbloc/credentials.json`.
+
+If recreating instead of restoring the same tunnel, create a new tunnel and update `cloudflared_tunnel_id` plus `credentials.json`.
+
+## Rebuild Commands
+
+Verify kubeconfig from the Terraform runner:
+
+```bash
+kubectl --kubeconfig ~/.kube/edge get nodes
+```
+
+Verify the Cloudflare credential file exists:
+
+```bash
+test -f examples/edge/appbloc/credentials.json
+```
+
+Verify the static site file exists:
+
+```bash
+test -f examples/edge/appbloc/static/index.html
+```
+
+Deploy:
+
+```bash
+cd examples/edge/appbloc
+terraform init -backend-config=backend/prd.conf
+terraform plan
+terraform apply
+```
+
+Validate:
+
+```bash
+kubectl --kubeconfig ~/.kube/edge get all -n appbloc
+kubectl --kubeconfig ~/.kube/edge get configmap -n appbloc web-html
+kubectl --kubeconfig ~/.kube/edge get secret -n appbloc cloudflared-credentials
+kubectl --kubeconfig ~/.kube/edge logs -n appbloc deploy/cloudflared
+curl http://<tiny-lan-ip>:30081
+curl https://cloudbloc.io
+curl https://www.cloudbloc.io
+```
+
+Expected Terraform outputs:
+
+```text
+service_name       = cloudbloc-webapp-prd-svc
+service_namespace  = appbloc
+service_node_port  = 30081
+```
+
+## Live-State Audit Commands
+
+Once `~/.kube/edge`, `credentials.json`, and GCP backend access are available, use these commands to compare actual deployed state with Terraform:
+
+```bash
+cd examples/edge/appbloc
+terraform init -backend-config=backend/prd.conf
+terraform state list
+terraform plan
+```
+
+```bash
+kubectl --kubeconfig ~/.kube/edge get all -n appbloc
+kubectl --kubeconfig ~/.kube/edge get service -n appbloc cloudbloc-webapp-prd-svc -o wide
+kubectl --kubeconfig ~/.kube/edge get configmap -n appbloc web-html -o yaml
+kubectl --kubeconfig ~/.kube/edge get secret -n appbloc cloudflared-credentials
+kubectl --kubeconfig ~/.kube/edge get deployment -n appbloc cloudbloc-webapp-prd -o yaml
+kubectl --kubeconfig ~/.kube/edge get deployment -n appbloc cloudflared -o yaml
+kubectl --kubeconfig ~/.kube/edge logs -n appbloc deploy/cloudflared
+```
+
+Cloudflare-side checks:
+
+```bash
+cloudflared tunnel list
+cloudflared tunnel route dns list
+```
+
+## Not Fully Reproducible From The Repo Alone
+
+These are required but not reproducible from committed Terraform alone:
+
+- Tiny OS install.
+- Kubernetes install on the Tiny.
+- The actual Tiny LAN IP used for `curl http://<tiny-lan-ip>:30081`.
+- Kubeconfig at `~/.kube/edge`.
+- Cloudflare tunnel credentials JSON.
+- Cloudflare account state and DNS routes for `cloudbloc.io` and `www.cloudbloc.io`.
+- GCS Terraform backend bucket and remote state access.
+
+## Automation TODOs
+
+- Move hard-coded Cloudflare values from `examples/edge/appbloc/main.tf` into variables and an `appbloc.tfvars.example`.
+- Add a Tiny bootstrap script for Kubernetes install and NodePort reachability validation.
+- Add a preflight script that checks:
+  - `~/.kube/edge` exists and can reach the cluster.
+  - `credentials.json` exists.
+  - `static/index.html` exists.
+  - NodePort `30081` is available.
+  - Terraform can access `gs://cloudbloc-tfstate-prd/edge-appbloc`.
+- Automate Cloudflare tunnel creation and DNS route creation, or document how to import an existing tunnel.
+- Pin `cloudflare/cloudflared:latest` to a fixed version.
+- Add post-apply smoke tests for LAN NodePort and both public HTTPS hostnames.
+- Decide whether Edge AppBloc should use local state instead of the shared GCS backend, or document why reproducing the Tiny deployment depends on GCP state.

--- a/DROPBLOC_RESTORE.md
+++ b/DROPBLOC_RESTORE.md
@@ -1,0 +1,296 @@
+# DropBloc Restore Requirements
+
+This document records exactly what is needed to reproduce the DropBloc deployment from this repository.
+
+Current checkout status:
+
+- Branch `main` was pulled and was already up to date.
+- No local Terraform state directory or state file was found under `examples/edge/dropbloc`.
+- `examples/edge/dropbloc/credentials.json` is missing in this checkout.
+- `/home/yprk/.kube/edge` is missing on this machine.
+- Because the kubeconfig and Terraform state access are not present locally, this document is repo-derived. It does not prove what is currently live on the Tiny.
+
+## Terraform Entry Point
+
+Use this Terraform root:
+
+```bash
+examples/edge/dropbloc
+```
+
+Backend:
+
+```hcl
+terraform {
+  backend "gcs" {
+    prefix = "edge-dropbloc"
+  }
+}
+```
+
+Backend config:
+
+```hcl
+bucket = "cloudbloc-tfstate-prd"
+```
+
+Provider config:
+
+```hcl
+provider "kubernetes" {
+  config_path = "~/.kube/edge"
+}
+
+provider "helm" {
+  kubernetes = {
+    config_path = "~/.kube/edge"
+  }
+}
+```
+
+## Exact Committed DropBloc Inputs
+
+These values are currently hard-coded in `examples/edge/dropbloc/main.tf`:
+
+```hcl
+namespace      = "dropbloc"
+node_ip        = "10.0.0.187"
+data_host_path = "/mnt/dropbloc/nextcloud-data"
+data_size      = "800Gi"
+
+nextcloud_hostname           = "dropbloc.cloudbloc.io"
+nextcloud_canonical_host     = "10.0.0.187:30080"
+nextcloud_canonical_protocol = "http"
+
+admin_username = "admin"
+admin_password = "supersecurepassword"
+
+service_node_port = 30080
+
+enable_cloudflared           = true
+cloudflared_credentials_file = abspath("${path.module}/credentials.json")
+cloudflared_tunnel_id        = "26b4d1ec-384f-477e-a404-f3d7352b45db"
+
+nextcloud_files_scan_paths = [
+  "yprk/files/yt",
+  "donggu/files/yt",
+]
+
+nextcloud_cron_schedule = "*/5 * * * *"
+```
+
+Module source:
+
+```hcl
+source = "../../../blocs/edge/dropbloc"
+```
+
+## Resources Terraform Creates
+
+The DropBloc module creates:
+
+- Kubernetes namespace: `dropbloc`.
+- Kubernetes StorageClass: default `nextcloud-local-storage`.
+- Kubernetes PersistentVolume: `nextcloud-data-pv`.
+- Kubernetes PersistentVolumeClaim: `nextcloud-data-pvc` in namespace `dropbloc`.
+- Helm release: `nextcloud` in namespace `dropbloc`.
+- Nextcloud service exposed through NodePort `30080`.
+- Nextcloud internal database via the Helm chart.
+- Nextcloud cron job via the Helm chart, scheduled `*/5 * * * *`.
+- Optional Cloudflare tunnel resources because `enable_cloudflared = true`:
+  - Secret `cloudflared-credentials`.
+  - ConfigMap `cloudflared-config`.
+  - Secret `cloudflared-credentials-v1`.
+  - ConfigMap `cloudflared-config-v1`.
+  - Deployment `cloudflared`.
+
+Note: the module currently defines both unversioned and `_v1` Cloudflare Secret/ConfigMap resources, but the Deployment mounts the `_v1` versions.
+
+## Required Host State On The Tiny
+
+The Tiny must have:
+
+- LAN IP `10.0.0.187`, or the Terraform input must be changed.
+- Kubernetes installed and running.
+- A kubeconfig for the cluster copied to the Terraform runner at `~/.kube/edge`.
+- Local storage mounted so this path exists and persists:
+
+```bash
+/mnt/dropbloc/nextcloud-data
+```
+
+Prepare the storage path on the Tiny:
+
+```bash
+sudo mkdir -p /mnt/dropbloc/nextcloud-data
+sudo chmod 750 /mnt/dropbloc
+sudo chmod 770 /mnt/dropbloc/nextcloud-data
+sudo chown -R 33:33 /mnt/dropbloc/nextcloud-data
+```
+
+The UID/GID `33:33` is required because the Nextcloud chart is configured to run as that user/group.
+
+## Required Local Files
+
+The machine running Terraform needs:
+
+```bash
+~/.kube/edge
+examples/edge/dropbloc/credentials.json
+```
+
+Current local check:
+
+- `~/.kube/edge`: missing.
+- `examples/edge/dropbloc/credentials.json`: missing.
+
+`credentials.json` is intentionally ignored by git:
+
+```gitignore
+examples/edge/dropbloc/credentials.json
+```
+
+## Required External State
+
+### Terraform State
+
+Terraform expects remote state in:
+
+```text
+gs://cloudbloc-tfstate-prd/edge-dropbloc
+```
+
+To reproduce from existing state, the runner needs GCP auth with read/write access to the `cloudbloc-tfstate-prd` bucket.
+
+To reproduce from scratch, the bucket must exist before `terraform init`.
+
+### Cloudflare Tunnel
+
+The committed tunnel ID is:
+
+```text
+26b4d1ec-384f-477e-a404-f3d7352b45db
+```
+
+The public hostname is:
+
+```text
+dropbloc.cloudbloc.io
+```
+
+To reproduce exactly, Cloudflare must contain:
+
+- A tunnel with ID `26b4d1ec-384f-477e-a404-f3d7352b45db`.
+- DNS route for `dropbloc.cloudbloc.io` to that tunnel.
+- The matching tunnel credentials JSON at `examples/edge/dropbloc/credentials.json`.
+
+If recreating instead of restoring the same tunnel, create a new tunnel and update `cloudflared_tunnel_id` plus `credentials.json`.
+
+## Rebuild Commands
+
+Run host prep on the Tiny first:
+
+```bash
+sudo mkdir -p /mnt/dropbloc/nextcloud-data
+sudo chmod 750 /mnt/dropbloc
+sudo chmod 770 /mnt/dropbloc/nextcloud-data
+sudo chown -R 33:33 /mnt/dropbloc/nextcloud-data
+```
+
+Verify kubeconfig from the Terraform runner:
+
+```bash
+kubectl --kubeconfig ~/.kube/edge get nodes
+```
+
+Verify the Cloudflare credential file exists:
+
+```bash
+test -f examples/edge/dropbloc/credentials.json
+```
+
+Deploy:
+
+```bash
+cd examples/edge/dropbloc
+terraform init -backend-config=backend/prd.conf
+terraform plan
+terraform apply
+```
+
+Validate:
+
+```bash
+kubectl --kubeconfig ~/.kube/edge get all -n dropbloc
+kubectl --kubeconfig ~/.kube/edge get pv nextcloud-data-pv
+kubectl --kubeconfig ~/.kube/edge get pvc -n dropbloc nextcloud-data-pvc
+kubectl --kubeconfig ~/.kube/edge get storageclass nextcloud-local-storage
+kubectl --kubeconfig ~/.kube/edge get cronjob -n dropbloc nextcloud-cron
+kubectl --kubeconfig ~/.kube/edge logs -n dropbloc deploy/cloudflared
+curl http://10.0.0.187:30080
+```
+
+Expected outputs:
+
+```text
+nextcloud_lan_url    = http://10.0.0.187:30080
+nextcloud_public_url = dropbloc.cloudbloc.io
+```
+
+## Live-State Audit Commands
+
+Once `~/.kube/edge`, `credentials.json`, and GCP backend access are available, use these commands to compare actual deployed state with Terraform:
+
+```bash
+cd examples/edge/dropbloc
+terraform init -backend-config=backend/prd.conf
+terraform state list
+terraform plan
+```
+
+```bash
+kubectl --kubeconfig ~/.kube/edge get all -n dropbloc
+kubectl --kubeconfig ~/.kube/edge get pv,pvc -A
+kubectl --kubeconfig ~/.kube/edge get storageclass
+kubectl --kubeconfig ~/.kube/edge get secret,configmap -n dropbloc
+kubectl --kubeconfig ~/.kube/edge get cronjob,jobs -n dropbloc
+kubectl --kubeconfig ~/.kube/edge describe pv nextcloud-data-pv
+kubectl --kubeconfig ~/.kube/edge describe pvc -n dropbloc nextcloud-data-pvc
+```
+
+Cloudflare-side checks:
+
+```bash
+cloudflared tunnel list
+cloudflared tunnel route dns list
+```
+
+## Not Fully Reproducible From The Repo Alone
+
+These are required but not reproducible from committed Terraform alone:
+
+- Tiny OS install.
+- Kubernetes install on the Tiny.
+- Stable LAN IP assignment for `10.0.0.187`.
+- The mounted disk/filesystem behind `/mnt/dropbloc`.
+- Existing Nextcloud user files in `/mnt/dropbloc/nextcloud-data`.
+- Kubeconfig at `~/.kube/edge`.
+- Cloudflare tunnel credentials JSON.
+- Cloudflare account state and DNS route for `dropbloc.cloudbloc.io`.
+- GCS Terraform backend bucket and remote state access.
+
+## Automation TODOs
+
+- Move all hard-coded values from `examples/edge/dropbloc/main.tf` into variables and a `dropbloc.tfvars.example`.
+- Remove the committed placeholder `admin_password = "supersecurepassword"` and require it through ignored tfvars or a secret manager.
+- Add a Tiny bootstrap script for Kubernetes install, static IP verification, storage mount, and directory permissions.
+- Add a preflight script that checks:
+  - `~/.kube/edge` exists and can reach the cluster.
+  - `credentials.json` exists.
+  - `10.0.0.187` is reachable.
+  - `/mnt/dropbloc/nextcloud-data` exists on the Tiny and is owned by `33:33`.
+  - Terraform can access `gs://cloudbloc-tfstate-prd/edge-dropbloc`.
+- Automate Cloudflare tunnel creation and DNS route creation, or document how to import an existing tunnel.
+- Pin `cloudflare/cloudflared:latest` to a fixed version.
+- Remove duplicate unversioned Cloudflare Secret/ConfigMap resources if they are not used.
+- Add a backup and restore procedure for `/mnt/dropbloc/nextcloud-data`.

--- a/RESTORE_CHECKLIST.md
+++ b/RESTORE_CHECKLIST.md
@@ -1,0 +1,294 @@
+# Restore Checklist
+
+This checklist is based on the current `main` branch after `git pull --ff-only origin main` reported `Already up to date`.
+
+Scope: analysis only. No infrastructure changes have been made.
+
+## 1. What Terraform Manages
+
+### Shared GCP Foundation
+
+- `foundation/gcp/networks`
+  - Creates the shared Cloud Armor policy through `modules/gcp/cloudarmor`.
+  - Uses GCS remote state bucket `cloudbloc-tfstate-prd` with prefix `foundation/networks`.
+
+- `foundation/gcp/clusters`
+  - Creates a GKE cluster named `cloudbloc-gke-${environment}` through `modules/gcp/gke`.
+  - Current foundation stack sets `enable_autopilot = true`.
+  - Enables VPC-native networking and Workload Identity.
+  - Uses GCS remote state bucket `cloudbloc-tfstate-prd` with prefix `foundation`.
+
+### GCP Blocs
+
+- `blocs/gcp/appbloc`
+  - Kubernetes namespace, Deployment, Service, optional static HTML ConfigMap.
+  - GKE `ManagedCertificate`, `FrontendConfig`, GCE Ingress.
+  - Global static IP.
+  - Cloud DNS managed zone when `create_dns_zone = true`, or DNS records in an existing zone when false.
+  - Optional Cloud Armor policy annotation on the Ingress.
+
+- `blocs/gcp/obsbloc`
+  - Kubernetes namespace.
+  - Grafana Deployment, Service, ConfigMaps for `grafana.ini`, datasource, dashboard provider, dashboards.
+  - Prometheus ServiceAccount, RBAC, ConfigMaps, PVC, Deployment, Service.
+  - Alertmanager ConfigMap, Deployment, Service.
+  - GKE `ManagedCertificate`, `FrontendConfig`, GCE Ingress.
+  - Global static IP.
+  - Cloud DNS A records for ObsBloc and, when enabled, SearchBloc hostnames.
+  - Optional Cloud Armor policy annotation on the Ingress.
+
+- `blocs/gcp/searchbloc`
+  - Meilisearch/Nginx Kubernetes Deployment, Service, PVC, ConfigMaps, Secret.
+  - GCS backup bucket with versioning, retention, and lifecycle policy.
+  - GCP service account for backups.
+  - Bucket IAM binding and Workload Identity IAM binding.
+  - Kubernetes ServiceAccount for backup jobs.
+  - Daily Kubernetes CronJob that syncs Meilisearch data to GCS.
+
+- `blocs/gcp/sitebloc`
+  - GCS bucket configured for static website hosting.
+  - Public `roles/storage.objectViewer` bucket IAM binding.
+
+### Edge / Tiny Blocs
+
+- `blocs/edge/appbloc`
+  - Kubernetes namespace, Deployment, NodePort Service, optional static HTML ConfigMap.
+  - Optional worker CronJob with optional hostPath mounts.
+  - Optional in-cluster `cloudflared` Secret, ConfigMap, and Deployment.
+
+- `blocs/edge/dropbloc`
+  - Kubernetes namespace.
+  - Local no-provisioner StorageClass.
+  - Static hostPath PersistentVolume and bound PVC.
+  - Nextcloud Helm release.
+  - Optional in-cluster `cloudflared` Secret, ConfigMap, and Deployment.
+  - Nextcloud cron job through the Helm chart.
+
+## 2. Likely Manual Setup Steps
+
+- Create or recover the GCS Terraform state bucket `cloudbloc-tfstate-prd` before running any remote-backend Terraform stack.
+- Authenticate to GCP locally with Application Default Credentials.
+- Enable required GCP APIs. Docs mention at least `compute.googleapis.com`, `container.googleapis.com`, and `dns.googleapis.com`; SearchBloc also needs storage and IAM APIs.
+- Ensure the target GCP project exists and is accessible. Most examples default to `potent-thought-470914-t1`.
+- Decide whether Cloud DNS zones are created by Terraform or are pre-existing:
+  - AppBloc example sets `create_dns_zone = true`.
+  - ObsBloc expects an existing Cloud DNS managed zone named `cloudbloc-io` by default.
+- Ensure domain registrar nameservers point to Cloud DNS when Terraform creates a new managed zone. Terraform creates the zone and records, but registrar delegation is still outside this repo.
+- Wait for GKE managed certificates to become active after DNS resolves to the load balancer IP.
+- Provide ignored per-environment `*.tfvars` files for required variables such as `region` and secrets.
+- For GCP Kubernetes examples, ensure the target GKE cluster already exists before applying bloc examples that use `data.google_container_cluster.gke`.
+- For SearchBloc, decide whether existing Meilisearch data must be restored from a GCS backup. Terraform creates the PVC and backup job but does not provide a restore job.
+- For Edge/Tiny deployments, provision the Tiny host manually:
+  - Install the operating system.
+  - Assign or reserve the LAN IP used by Terraform examples, currently `10.0.0.187`.
+  - Install and configure Kubernetes such as k3s, MicroK8s, or equivalent.
+  - Put a working kubeconfig at `~/.kube/edge` on the machine running Terraform.
+  - Install or mount local storage at `/mnt/dropbloc`.
+  - Prepare `/mnt/dropbloc/nextcloud-data` ownership and permissions for Nextcloud UID/GID `33`.
+- For Edge/Tiny Cloudflare access:
+  - Install `cloudflared` locally for tunnel setup.
+  - Run `cloudflared tunnel login`.
+  - Create tunnels.
+  - Route DNS names to tunnels.
+  - Place the generated `credentials.json` in the relevant example directory or pass another path.
+- Review hard-coded edge example values before restore:
+  - `examples/edge/appbloc/main.tf` contains tunnel ID `109c1cc5-0788-4761-bbe6-06cfd05c769f` and hostname `cloudbloc.io`.
+  - `examples/edge/dropbloc/main.tf` contains node IP `10.0.0.187`, host path `/mnt/dropbloc/nextcloud-data`, hostname `dropbloc.cloudbloc.io`, tunnel ID `26b4d1ec-384f-477e-a404-f3d7352b45db`, and a placeholder admin password.
+
+## 3. Missing Secrets, Files, And Env Vars
+
+- `*.tfvars` and `*.tfvars.json` are ignored by git, so any production values are intentionally missing from the repo.
+- Required Terraform variables without committed values:
+  - `region` in most GCP foundation and example stacks.
+  - `master_key` for `examples/gcp/searchbloc`.
+- Sensitive Terraform inputs:
+  - `examples/gcp/searchbloc`: `master_key`.
+  - `blocs/gcp/searchbloc`: `master_key`.
+  - `blocs/edge/dropbloc`: `admin_password`.
+  - `blocs/edge/appbloc`: `cloudflared_credentials_json`.
+  - `blocs/edge/dropbloc`: `cloudflared_credentials_file`.
+- Missing local credential files:
+  - `examples/edge/appbloc/credentials.json`.
+  - `examples/edge/dropbloc/credentials.json`.
+  - `.gitignore` explicitly excludes these files.
+- Required local auth files:
+  - GCP ADC at `~/.config/gcloud/application_default_credentials.json`.
+  - Edge kubeconfig at `~/.kube/edge`.
+- Terraform backend dependency:
+  - GCS bucket `cloudbloc-tfstate-prd` must exist and be readable/writable before `terraform init -backend-config=backend/prd.conf`.
+- Static content files currently used by examples:
+  - `examples/gcp/appbloc/static/index.html`.
+  - `examples/gcp/appbloc/static/index_future.html`.
+  - `examples/edge/appbloc/static/index.html`.
+  - `examples/gcp/obsbloc/dashboards/k8s-overview.json`.
+  - `examples/gcp/obsbloc/dashboards/prometheus-internals.json`.
+  - `blocs/gcp/searchbloc/ui/index.html`.
+  - These are committed, but any customized production versions outside the repo would need to be restored separately.
+- No `.env` files are committed, and no shell scripts were found to recreate local environment variables.
+
+## 4. Host-Level Dependencies
+
+### Machine Running Terraform
+
+- `git`.
+- `terraform` >= 1.5 for the documented GCP examples.
+- `gcloud` CLI with authenticated ADC.
+- Network access to:
+  - GitHub module sources.
+  - Terraform provider registries.
+  - GCP APIs.
+  - Helm chart repositories for edge DropBloc.
+- For GCP stacks:
+  - IAM permissions to manage GKE, Compute global addresses, Cloud DNS, Cloud Armor, GCS, IAM service accounts/bindings, and Kubernetes resources in the cluster.
+- For edge stacks:
+  - Access to a Kubernetes cluster through `~/.kube/edge`.
+  - `kubectl` for validation and troubleshooting.
+  - `cloudflared` for one-time tunnel creation and DNS routing.
+
+### Fresh Tiny Host
+
+- Operating system installed and reachable on the LAN.
+- Stable LAN IP, currently expected by examples as `10.0.0.187`.
+- Kubernetes installed and running, for example k3s or MicroK8s.
+- Kubeconfig exported from the Tiny to the Terraform runner as `~/.kube/edge`.
+- Container runtime and CNI installed as part of Kubernetes.
+- Local storage mounted at `/mnt/dropbloc`.
+- Nextcloud data directory prepared:
+  - `/mnt/dropbloc/nextcloud-data`.
+  - Owned by UID/GID `33:33`.
+  - Permissions compatible with Nextcloud, currently documented as `770` for data and `750` for parent directory.
+- Outbound internet access from the Tiny for:
+  - Pulling container images.
+  - Reaching Cloudflare Tunnel endpoints.
+  - Downloading Helm chart images and dependencies.
+
+## 5. Commands Needed To Rebuild On A Fresh Tiny
+
+Adjust paths, IPs, secrets, and tunnel IDs before running these. Commands are written from the repo root unless noted.
+
+### Prepare The Tiny Host
+
+```bash
+sudo mkdir -p /mnt/dropbloc/nextcloud-data
+sudo chmod 750 /mnt/dropbloc
+sudo chmod 770 /mnt/dropbloc/nextcloud-data
+sudo chown -R 33:33 /mnt/dropbloc/nextcloud-data
+```
+
+Install Kubernetes on the Tiny, then copy/export its kubeconfig to the Terraform runner:
+
+```bash
+mkdir -p ~/.kube
+# Copy the Tiny kubeconfig to:
+# ~/.kube/edge
+kubectl --kubeconfig ~/.kube/edge get nodes
+```
+
+### Prepare Cloudflare Tunnel Credentials
+
+```bash
+cloudflared tunnel login
+cloudflared tunnel create appbloc-tunnel
+cloudflared tunnel route dns appbloc-tunnel cloudbloc.io
+cloudflared tunnel route dns appbloc-tunnel www.cloudbloc.io
+
+cloudflared tunnel create dropbloc-tunnel
+cloudflared tunnel route dns dropbloc-tunnel dropbloc.cloudbloc.io
+```
+
+Copy the generated credentials into the example directories or update Terraform variables to point elsewhere:
+
+```bash
+cp ~/.cloudflared/<appbloc-tunnel-id>.json examples/edge/appbloc/credentials.json
+cp ~/.cloudflared/<dropbloc-tunnel-id>.json examples/edge/dropbloc/credentials.json
+```
+
+### Deploy Edge AppBloc
+
+```bash
+cd examples/edge/appbloc
+terraform init -backend-config=backend/prd.conf
+terraform plan
+terraform apply
+kubectl --kubeconfig ~/.kube/edge get pods -n appbloc
+kubectl --kubeconfig ~/.kube/edge logs -n appbloc deploy/cloudflared
+curl http://10.0.0.187:30081
+```
+
+### Deploy Edge DropBloc
+
+Before applying, replace the committed placeholder `admin_password`, confirm `node_ip`, confirm `data_host_path`, and confirm Cloudflare tunnel values.
+
+```bash
+cd examples/edge/dropbloc
+terraform init -backend-config=backend/prd.conf
+terraform plan
+terraform apply
+kubectl --kubeconfig ~/.kube/edge get pods -n dropbloc
+kubectl --kubeconfig ~/.kube/edge get cronjob -n dropbloc nextcloud-cron
+curl http://10.0.0.187:30080
+```
+
+### Optional GCP Rebuild Order
+
+```bash
+cd foundation/gcp/networks
+terraform init -backend-config=backend/prd.conf
+terraform plan -var-file=prd.tfvars
+terraform apply -var-file=prd.tfvars
+
+cd ../clusters
+terraform init -backend-config=backend/prd.conf
+terraform plan -var-file=prd.tfvars
+terraform apply -var-file=prd.tfvars
+
+cd ../../../examples/gcp/appbloc
+terraform init -backend-config=backend/prd.conf
+terraform plan -var-file=prd.tfvars
+terraform apply -var-file=prd.tfvars
+
+cd ../obsbloc
+terraform init -backend-config=backend/prd.conf
+terraform plan -var-file=prd.tfvars
+terraform apply -var-file=prd.tfvars
+
+cd ../searchbloc
+terraform init -backend-config=backend/prd.conf
+terraform plan -var-file=prd.tfvars
+terraform apply -var-file=prd.tfvars
+```
+
+## 6. TODOs To Automate Manual Steps
+
+- Add a bootstrap script or Terraform bootstrap stack for the remote state bucket `cloudbloc-tfstate-prd`.
+- Add documented `*.tfvars.example` files for every runnable stack with non-secret placeholders.
+- Move hard-coded edge values out of `examples/edge/appbloc/main.tf` and `examples/edge/dropbloc/main.tf` into variables.
+- Remove the committed placeholder `admin_password = "supersecurepassword"` from `examples/edge/dropbloc/main.tf`; require it via ignored tfvars or a secret manager.
+- Add validation/preflight scripts for:
+  - Terraform version.
+  - GCP auth and active project.
+  - Required GCP APIs.
+  - Existence and permissions of the remote state bucket.
+  - GKE cluster lookup before applying bloc examples.
+  - Edge kubeconfig at `~/.kube/edge`.
+  - Tiny node IP reachability.
+  - Required local files such as `credentials.json`.
+- Add a Tiny bootstrap script or Ansible playbook for:
+  - Installing k3s or MicroK8s.
+  - Exporting kubeconfig.
+  - Mounting local storage.
+  - Creating and permissioning `/mnt/dropbloc/nextcloud-data`.
+  - Setting a static IP or documenting DHCP reservation.
+- Add Terraform or scripted Cloudflare automation for tunnel creation and DNS route setup, instead of requiring `cloudflared tunnel ...` commands.
+- Add secret handling through SOPS, Vault, External Secrets Operator, or Cloudflare/GCP secret managers.
+- Add a SearchBloc restore job or documented one-shot restore procedure from the GCS backup bucket into the Meilisearch PVC.
+- Add validation around Cloud DNS delegation when AppBloc creates a new managed zone.
+- Add post-apply smoke-test scripts for:
+  - Kubernetes pod readiness.
+  - Cloudflare tunnel connectivity.
+  - NodePort LAN access.
+  - GKE managed certificate status.
+  - Public HTTPS endpoint health.
+- Pin `cloudflare/cloudflared:latest` to an explicit version for reproducible edge restores.
+- Review and remove duplicated DropBloc Cloudflare Secret/ConfigMap resources using both unversioned and `_v1` Kubernetes providers.
+- Decide whether edge examples should use local state instead of the shared GCS backend, or document why Tiny restores depend on GCP state.

--- a/blocs/edge/appbloc/README.md
+++ b/blocs/edge/appbloc/README.md
@@ -118,7 +118,7 @@ To reproduce an Appbloc Edge deployment on a fresh local node or Tiny, do these 
    Create the tunnel in your Cloudflare account, route your hostname and `www` hostname to it, and keep the generated credentials outside git.
 
    ```hcl
-   cloudflared_hostname         = "app.mydomain.com"
+   cloudflared_hostname         = "cloudbloc.io"
    cloudflared_tunnel_id        = "123e4567-e89b-12d3-a456-426614174000"
    cloudflared_credentials_json = file("${path.module}/credentials.json")
    ```
@@ -143,7 +143,7 @@ To reproduce an Appbloc Edge deployment on a fresh local node or Tiny, do these 
    kubectl -n appbloc get all
    kubectl -n appbloc logs deploy/cloudflared
    curl http://192.168.1.50:30081
-   curl https://app.mydomain.com
+   curl https://cloudbloc.io
    ```
 
 ---
@@ -157,7 +157,7 @@ static/index.html
 credentials.json
 ```
 
-And you want to serve `app.mydomain.com` from your homelab:
+And you want to serve `cloudbloc.io` from your homelab:
 
 ```hcl
 locals {
@@ -188,7 +188,7 @@ module "appbloc" {
   # Enable Cloudflare Tunnel for HTTPS public access
   enable_cloudflared           = true
   cloudflared_tunnel_id        = "123e4567-e89b-12d3-a456-426614174000"
-  cloudflared_hostname         = "app.mydomain.com"
+  cloudflared_hostname         = "cloudbloc.io"
   cloudflared_credentials_json = file("${path.module}/credentials.json")
 }
 ```
@@ -236,8 +236,8 @@ cp ~/.cloudflared/<id>.json edge-appbloc/credentials.json
 5. Add DNS routes:
 
 ```bash
-cloudflared tunnel route dns appbloc-tunnel app.mydomain.com
-cloudflared tunnel route dns appbloc-tunnel www.app.mydomain.com
+cloudflared tunnel route dns appbloc-tunnel cloudbloc.io
+cloudflared tunnel route dns appbloc-tunnel www.cloudbloc.io
 ```
 
 ---
@@ -323,7 +323,7 @@ curl http://192.168.1.50:30081
 ### Test public:
 
 ```
-https://app.mydomain.com
+https://cloudbloc.io
 ```
 
 ---
@@ -335,8 +335,8 @@ https://app.mydomain.com
 Ensure ConfigMap includes:
 
 ```
-- hostname: app.mydomain.com
-- hostname: www.app.mydomain.com
+- hostname: cloudbloc.io
+- hostname: www.cloudbloc.io
 ```
 
 ### Error: “record already exists”

--- a/blocs/edge/appbloc/README.md
+++ b/blocs/edge/appbloc/README.md
@@ -73,6 +73,81 @@ If `enable_cloudflared = true`:
 
 ---
 
+# 🔁 Manual Restore Checklist
+
+To reproduce an Appbloc Edge deployment on a fresh local node or Tiny, do these manual steps before running Terraform:
+
+1. Install the OS and Kubernetes on the node.
+
+   Appbloc expects a working Kubernetes cluster. Installing k3s, MicroK8s, or another Kubernetes distribution is outside this module.
+
+2. Assign a stable LAN IP.
+
+   Reserve or statically configure the node IP you will use for LAN NodePort access. The module does not need the IP as an input, but users need it to test the NodePort URL:
+
+   ```bash
+   curl http://192.168.1.50:30081
+   ```
+
+3. Choose an available NodePort.
+
+   Pick a port in the Kubernetes NodePort range, usually `30000-32767`, and pass it as `node_port`.
+
+   ```hcl
+   node_port = 30081
+   ```
+
+4. Copy kubeconfig to the machine running Terraform.
+
+   Point the Kubernetes and Helm providers at that kubeconfig, then verify access:
+
+   ```bash
+   kubectl --kubeconfig ~/.kube/edge get nodes
+   ```
+
+5. Prepare static content if using static HTML mode.
+
+   If `enable_static_html = true`, make sure the file passed through `html_path` exists in your Terraform root, for example:
+
+   ```text
+   static/index.html
+   ```
+
+6. If using Cloudflare Tunnel, create or restore the tunnel.
+
+   Create the tunnel in your Cloudflare account, route your hostname and `www` hostname to it, and keep the generated credentials outside git.
+
+   ```hcl
+   cloudflared_hostname         = "app.example.com"
+   cloudflared_tunnel_id        = "YOUR-TUNNEL-ID"
+   cloudflared_credentials_json = file("${path.module}/credentials.json")
+   ```
+
+7. Provide any app environment variables through local inputs.
+
+   Use `env` only for non-secret variables. Do not commit passwords, API keys, kubeconfigs, tunnel credentials, or `.tfvars` files containing secrets.
+
+8. Initialize and apply Terraform from your Appbloc root.
+
+   If your root uses a remote backend, make sure the backend bucket/state location already exists and your local credentials can access it.
+
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+9. Validate the deployment.
+
+   ```bash
+   kubectl -n appbloc get all
+   kubectl -n appbloc logs deploy/cloudflared
+   curl http://192.168.1.50:30081
+   curl https://app.example.com
+   ```
+
+---
+
 # 📁 Example Usage
 
 Assuming your Terraform root has:
@@ -82,7 +157,7 @@ static/index.html
 credentials.json
 ```
 
-And you want to serve `cloudbloc.io` from your homelab:
+And you want to serve `app.example.com` from your homelab:
 
 ```hcl
 locals {
@@ -112,8 +187,8 @@ module "appbloc" {
 
   # Enable Cloudflare Tunnel for HTTPS public access
   enable_cloudflared           = true
-  cloudflared_tunnel_id        = "109c1cc5-0788-4761-bbe6-06cfd05c769f"
-  cloudflared_hostname         = "cloudbloc.io"
+  cloudflared_tunnel_id        = "YOUR-TUNNEL-ID"
+  cloudflared_hostname         = "app.example.com"
   cloudflared_credentials_json = file("${path.module}/credentials.json")
 }
 ```
@@ -161,8 +236,8 @@ cp ~/.cloudflared/<id>.json edge-appbloc/credentials.json
 5. Add DNS routes:
 
 ```bash
-cloudflared tunnel route dns appbloc-tunnel cloudbloc.io
-cloudflared tunnel route dns appbloc-tunnel www.cloudbloc.io
+cloudflared tunnel route dns appbloc-tunnel app.example.com
+cloudflared tunnel route dns appbloc-tunnel www.app.example.com
 ```
 
 ---
@@ -242,13 +317,13 @@ kubectl logs -n appbloc deploy/cloudflared -f
 ### Test LAN:
 
 ```bash
-curl http://10.0.0.187:30081
+curl http://192.168.1.50:30081
 ```
 
 ### Test public:
 
 ```
-https://cloudbloc.io
+https://app.example.com
 ```
 
 ---
@@ -260,8 +335,8 @@ https://cloudbloc.io
 Ensure ConfigMap includes:
 
 ```
-- hostname: cloudbloc.io
-- hostname: www.cloudbloc.io
+- hostname: app.example.com
+- hostname: www.app.example.com
 ```
 
 ### Error: “record already exists”

--- a/blocs/edge/appbloc/README.md
+++ b/blocs/edge/appbloc/README.md
@@ -86,7 +86,7 @@ To reproduce an Appbloc Edge deployment on a fresh local node or Tiny, do these 
    Reserve or statically configure the node IP you will use for LAN NodePort access. The module does not need the IP as an input, but users need it to test the NodePort URL:
 
    ```bash
-   curl http://192.168.1.50:30081
+   curl http://10.0.0.187:30081
    ```
 
 3. Choose an available NodePort.
@@ -119,7 +119,7 @@ To reproduce an Appbloc Edge deployment on a fresh local node or Tiny, do these 
 
    ```hcl
    cloudflared_hostname         = "cloudbloc.io"
-   cloudflared_tunnel_id        = "123e4567-e89b-12d3-a456-426614174000"
+   cloudflared_tunnel_id        = "109c1cc5-0788-4761-bbe6-06cfd05c769f"
    cloudflared_credentials_json = file("${path.module}/credentials.json")
    ```
 
@@ -142,7 +142,7 @@ To reproduce an Appbloc Edge deployment on a fresh local node or Tiny, do these 
    ```bash
    kubectl -n appbloc get all
    kubectl -n appbloc logs deploy/cloudflared
-   curl http://192.168.1.50:30081
+   curl http://10.0.0.187:30081
    curl https://cloudbloc.io
    ```
 
@@ -187,7 +187,7 @@ module "appbloc" {
 
   # Enable Cloudflare Tunnel for HTTPS public access
   enable_cloudflared           = true
-  cloudflared_tunnel_id        = "123e4567-e89b-12d3-a456-426614174000"
+  cloudflared_tunnel_id        = "109c1cc5-0788-4761-bbe6-06cfd05c769f"
   cloudflared_hostname         = "cloudbloc.io"
   cloudflared_credentials_json = file("${path.module}/credentials.json")
 }
@@ -317,7 +317,7 @@ kubectl logs -n appbloc deploy/cloudflared -f
 ### Test LAN:
 
 ```bash
-curl http://192.168.1.50:30081
+curl http://10.0.0.187:30081
 ```
 
 ### Test public:

--- a/blocs/edge/appbloc/README.md
+++ b/blocs/edge/appbloc/README.md
@@ -118,8 +118,8 @@ To reproduce an Appbloc Edge deployment on a fresh local node or Tiny, do these 
    Create the tunnel in your Cloudflare account, route your hostname and `www` hostname to it, and keep the generated credentials outside git.
 
    ```hcl
-   cloudflared_hostname         = "app.example.com"
-   cloudflared_tunnel_id        = "YOUR-TUNNEL-ID"
+   cloudflared_hostname         = "app.mydomain.com"
+   cloudflared_tunnel_id        = "123e4567-e89b-12d3-a456-426614174000"
    cloudflared_credentials_json = file("${path.module}/credentials.json")
    ```
 
@@ -143,7 +143,7 @@ To reproduce an Appbloc Edge deployment on a fresh local node or Tiny, do these 
    kubectl -n appbloc get all
    kubectl -n appbloc logs deploy/cloudflared
    curl http://192.168.1.50:30081
-   curl https://app.example.com
+   curl https://app.mydomain.com
    ```
 
 ---
@@ -157,7 +157,7 @@ static/index.html
 credentials.json
 ```
 
-And you want to serve `app.example.com` from your homelab:
+And you want to serve `app.mydomain.com` from your homelab:
 
 ```hcl
 locals {
@@ -187,8 +187,8 @@ module "appbloc" {
 
   # Enable Cloudflare Tunnel for HTTPS public access
   enable_cloudflared           = true
-  cloudflared_tunnel_id        = "YOUR-TUNNEL-ID"
-  cloudflared_hostname         = "app.example.com"
+  cloudflared_tunnel_id        = "123e4567-e89b-12d3-a456-426614174000"
+  cloudflared_hostname         = "app.mydomain.com"
   cloudflared_credentials_json = file("${path.module}/credentials.json")
 }
 ```
@@ -236,8 +236,8 @@ cp ~/.cloudflared/<id>.json edge-appbloc/credentials.json
 5. Add DNS routes:
 
 ```bash
-cloudflared tunnel route dns appbloc-tunnel app.example.com
-cloudflared tunnel route dns appbloc-tunnel www.app.example.com
+cloudflared tunnel route dns appbloc-tunnel app.mydomain.com
+cloudflared tunnel route dns appbloc-tunnel www.app.mydomain.com
 ```
 
 ---
@@ -323,7 +323,7 @@ curl http://192.168.1.50:30081
 ### Test public:
 
 ```
-https://app.example.com
+https://app.mydomain.com
 ```
 
 ---
@@ -335,8 +335,8 @@ https://app.example.com
 Ensure ConfigMap includes:
 
 ```
-- hostname: app.example.com
-- hostname: www.app.example.com
+- hostname: app.mydomain.com
+- hostname: www.app.mydomain.com
 ```
 
 ### Error: “record already exists”

--- a/blocs/edge/dropbloc/README.md
+++ b/blocs/edge/dropbloc/README.md
@@ -26,7 +26,7 @@ Everything is fully automated through Terraform.
 
 | Variable                           | Description                                        |
 | ---------------------------------- | -------------------------------------------------- |
-| `node_ip`                          | LAN IP of your local or node (ex: `192.168.1.50`)   |
+| `node_ip`                          | LAN IP of your local or node (ex: `10.0.0.187`)   |
 | `data_host_path`                   | Directory on your SSD/NVMe to store Nextcloud data |
 | `admin_username`, `admin_password` | Nextcloud admin login                              |
 
@@ -78,7 +78,7 @@ To reproduce a Dropbloc deployment on a fresh local node or Tiny, do these manua
    Reserve or statically configure the IP you will pass as `node_ip`, for example:
 
    ```hcl
-   node_ip = "192.168.1.50"
+   node_ip = "10.0.0.187"
    ```
 
 3. Mount persistent storage.
@@ -108,7 +108,7 @@ To reproduce a Dropbloc deployment on a fresh local node or Tiny, do these manua
 
    ```hcl
    nextcloud_hostname           = "dropbloc.cloudbloc.io"
-   cloudflared_tunnel_id        = "123e4567-e89b-12d3-a456-426614174000"
+   cloudflared_tunnel_id        = "26b4d1ec-384f-477e-a404-f3d7352b45db"
    cloudflared_credentials_file = abspath("${path.module}/credentials.json")
    ```
 
@@ -131,7 +131,7 @@ To reproduce a Dropbloc deployment on a fresh local node or Tiny, do these manua
    ```bash
    kubectl -n dropbloc get all
    kubectl -n dropbloc get cronjob nextcloud-cron
-   curl http://192.168.1.50:30080
+   curl http://10.0.0.187:30080
    ```
 
 ---
@@ -146,12 +146,12 @@ module "dropbloc" {
   source = "github.com/cloudbloc/cloudbloc//blocs/edge/dropbloc"
 
   namespace      = "dropbloc"
-  node_ip        = "192.168.1.50"
+  node_ip        = "10.0.0.187"
   data_host_path = "/mnt/dropbloc/nextcloud-data"
   data_size      = "800Gi"
 
   # Canonical host tells Nextcloud what URLs to generate internally
-  nextcloud_canonical_host     = "192.168.1.50:30080"
+  nextcloud_canonical_host     = "10.0.0.187:30080"
   nextcloud_canonical_protocol = "http"
 
   # You can leave hostname blank if not using Cloudflare
@@ -168,7 +168,7 @@ module "dropbloc" {
 After apply:
 
 👉 **Open Nextcloud:**
-`http://192.168.1.50:30080`
+`http://10.0.0.187:30080`
 
 ---
 
@@ -189,7 +189,7 @@ module "dropbloc" {
   source = "github.com/cloudbloc/cloudbloc//blocs/edge/dropbloc"
 
   namespace      = "dropbloc"
-  node_ip        = "192.168.1.50"
+  node_ip        = "10.0.0.187"
   data_host_path = "/mnt/dropbloc/nextcloud-data"
   data_size      = "800Gi"
 
@@ -210,14 +210,14 @@ module "dropbloc" {
 
   # USER-SPECIFIC:
   cloudflared_credentials_file = abspath("${path.module}/credentials.json")
-  cloudflared_tunnel_id        = "123e4567-e89b-12d3-a456-426614174000"
+  cloudflared_tunnel_id        = "26b4d1ec-384f-477e-a404-f3d7352b45db"
 }
 ```
 
 After apply:
 
 👉 **LAN Access:**
-`http://192.168.1.50:30080`
+`http://10.0.0.187:30080`
 
 👉 **Public HTTPS Access:**
 `https://dropbloc.cloudbloc.io`
@@ -245,7 +245,7 @@ kubectl -n dropbloc logs job/<latest-nextcloud-cron-job>
 After `apply`, Terraform prints:
 
 ```txt
-nextcloud_lan_url    = http://192.168.1.50:30080
+nextcloud_lan_url    = http://10.0.0.187:30080
 nextcloud_public_url = dropbloc.cloudbloc.io
 ```
 
@@ -261,7 +261,7 @@ nextcloud_public_url = dropbloc.cloudbloc.io
 
 ### Security
 
-* LAN IP (e.g., `192.168.1.50`) is **not public**
+* LAN IP (e.g., `10.0.0.187`) is **not public**
 * Even if someone joins your WiFi, they can easily discover LAN hosts:
 
   * `arp -a`

--- a/blocs/edge/dropbloc/README.md
+++ b/blocs/edge/dropbloc/README.md
@@ -107,8 +107,8 @@ To reproduce a Dropbloc deployment on a fresh local node or Tiny, do these manua
    Create the tunnel in your Cloudflare account, route your hostname to it, and keep the generated `credentials.json` outside git.
 
    ```hcl
-   nextcloud_hostname           = "cloud.example.com"
-   cloudflared_tunnel_id        = "YOUR-TUNNEL-ID"
+   nextcloud_hostname           = "cloud.mydomain.com"
+   cloudflared_tunnel_id        = "123e4567-e89b-12d3-a456-426614174000"
    cloudflared_credentials_file = abspath("${path.module}/credentials.json")
    ```
 
@@ -210,7 +210,7 @@ module "dropbloc" {
 
   # USER-SPECIFIC:
   cloudflared_credentials_file = abspath("${path.module}/credentials.json")
-  cloudflared_tunnel_id        = "YOUR-TUNNEL-ID"
+  cloudflared_tunnel_id        = "123e4567-e89b-12d3-a456-426614174000"
 }
 ```
 

--- a/blocs/edge/dropbloc/README.md
+++ b/blocs/edge/dropbloc/README.md
@@ -65,7 +65,78 @@ If the directory exists and is writable, Dropbloc will use it.
 
 ---
 
-# 🚀 **2. Example Usage: LAN-Only Setup (no Cloudflare)**
+# 🔁 **2. Manual Restore Checklist**
+
+To reproduce a Dropbloc deployment on a fresh local node or Tiny, do these manual steps before running Terraform:
+
+1. Install the OS and Kubernetes on the node.
+
+   Dropbloc expects a working Kubernetes cluster. Installing k3s, MicroK8s, or another Kubernetes distribution is outside this module.
+
+2. Assign a stable LAN IP.
+
+   Reserve or statically configure the IP you will pass as `node_ip`, for example:
+
+   ```hcl
+   node_ip = "192.168.1.50"
+   ```
+
+3. Mount persistent storage.
+
+   Format and mount the SSD/NVMe/disk that will back `data_host_path`. The mount must survive reboot.
+
+4. Prepare the Nextcloud data directory on the node.
+
+   ```bash
+   sudo mkdir -p /mnt/dropbloc/nextcloud-data
+   sudo chmod 750 /mnt/dropbloc
+   sudo chmod 770 /mnt/dropbloc/nextcloud-data
+   sudo chown -R 33:33 /mnt/dropbloc/nextcloud-data
+   ```
+
+5. Copy kubeconfig to the machine running Terraform.
+
+   Point the Kubernetes and Helm providers at that kubeconfig, then verify access:
+
+   ```bash
+   kubectl --kubeconfig ~/.kube/edge get nodes
+   ```
+
+6. If using Cloudflare Tunnel, create or restore the tunnel.
+
+   Create the tunnel in your Cloudflare account, route your hostname to it, and keep the generated `credentials.json` outside git.
+
+   ```hcl
+   nextcloud_hostname           = "cloud.example.com"
+   cloudflared_tunnel_id        = "YOUR-TUNNEL-ID"
+   cloudflared_credentials_file = abspath("${path.module}/credentials.json")
+   ```
+
+7. Provide secrets through local inputs.
+
+   Use a strong `admin_password`. Do not commit real passwords, kubeconfigs, tunnel credentials, or `.tfvars` files containing secrets.
+
+8. Initialize and apply Terraform from your Dropbloc root.
+
+   If your root uses a remote backend, make sure the backend bucket/state location already exists and your local credentials can access it.
+
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+9. Validate the deployment.
+
+   ```bash
+   kubectl -n dropbloc get all
+   kubectl -n dropbloc get cronjob nextcloud-cron
+   curl http://192.168.1.50:30080
+   ```
+
+---
+
+# 🚀 **3. Example Usage: LAN-Only Setup (no Cloudflare)**
 
 This is the simplest setup.
 Nextcloud is only available on your **local network**.
@@ -101,7 +172,7 @@ After apply:
 
 ---
 
-# 🌐 **3. Example Usage: LAN + Cloudflare Tunnel (Public HTTPS)**
+# 🌐 **4. Example Usage: LAN + Cloudflare Tunnel (Public HTTPS)**
 
 To expose Nextcloud globally without opening ports:
 
@@ -153,7 +224,7 @@ After apply:
 
 ---
 
-# ⏱ **4. Nextcloud Cron Runner**
+# ⏱ **5. Nextcloud Cron Runner**
 
 Nextcloud’s `backgroundjobs_mode = cron` requires `cron.php` to run frequently or file metadata (like uploads created by other pods) will fall behind. Dropbloc enables the Helm chart’s built-in CronJob (`nextcloud-cron`) so Kubernetes handles `php -f /var/www/html/cron.php -- --verbose` every 5 minutes by default using the same image as the primary app.
 
@@ -169,7 +240,7 @@ kubectl -n dropbloc logs job/<latest-nextcloud-cron-job>
 
 ---
 
-# 🛠️ **5. Outputs**
+# 🛠️ **6. Outputs**
 
 After `apply`, Terraform prints:
 
@@ -180,7 +251,7 @@ nextcloud_public_url = cloud.mydomain.com
 
 ---
 
-# 🧪 **6. Tips & Best Practices**
+# 🧪 **7. Tips & Best Practices**
 
 ### Storage
 

--- a/blocs/edge/dropbloc/README.md
+++ b/blocs/edge/dropbloc/README.md
@@ -34,7 +34,7 @@ Everything is fully automated through Terraform.
 
 | Variable                       | Description                             |
 | ------------------------------ | --------------------------------------- |
-| `nextcloud_hostname`           | Ex: `cloud.mydomain.com`                |
+| `nextcloud_hostname`           | Ex: `dropbloc.cloudbloc.io`                |
 | `cloudflared_credentials_file` | Path to **your** Tunnel credential JSON |
 | `cloudflared_tunnel_id`        | Your Cloudflare Tunnel UUID             |
 
@@ -107,7 +107,7 @@ To reproduce a Dropbloc deployment on a fresh local node or Tiny, do these manua
    Create the tunnel in your Cloudflare account, route your hostname to it, and keep the generated `credentials.json` outside git.
 
    ```hcl
-   nextcloud_hostname           = "cloud.mydomain.com"
+   nextcloud_hostname           = "dropbloc.cloudbloc.io"
    cloudflared_tunnel_id        = "123e4567-e89b-12d3-a456-426614174000"
    cloudflared_credentials_file = abspath("${path.module}/credentials.json")
    ```
@@ -194,8 +194,8 @@ module "dropbloc" {
   data_size      = "800Gi"
 
   # Public hostname used by Cloudflare + canonical URLs
-  nextcloud_hostname           = "cloud.mydomain.com"
-  nextcloud_canonical_host     = "cloud.mydomain.com"
+  nextcloud_hostname           = "dropbloc.cloudbloc.io"
+  nextcloud_canonical_host     = "dropbloc.cloudbloc.io"
   nextcloud_canonical_protocol = "https"
 
   admin_username = "admin"
@@ -220,7 +220,7 @@ After apply:
 `http://192.168.1.50:30080`
 
 👉 **Public HTTPS Access:**
-`https://cloud.mydomain.com`
+`https://dropbloc.cloudbloc.io`
 
 ---
 
@@ -246,7 +246,7 @@ After `apply`, Terraform prints:
 
 ```txt
 nextcloud_lan_url    = http://192.168.1.50:30080
-nextcloud_public_url = cloud.mydomain.com
+nextcloud_public_url = dropbloc.cloudbloc.io
 ```
 
 ---


### PR DESCRIPTION
## Summary

Adds restore/reproducibility documentation for the Cloudbloc repo, with focused restore docs for Edge DropBloc and Edge AppBloc.

## Added

- `RESTORE_CHECKLIST.md`
  - repo-wide analysis of what Terraform manages
  - likely manual setup steps
  - missing secrets/files/env vars
  - host-level dependencies
  - fresh Tiny rebuild commands
  - TODOs to automate manual steps

- `DROPBLOC_RESTORE.md`
  - exact committed DropBloc inputs
  - Kubernetes/Helm resources Terraform creates
  - required Tiny host state
  - required local files and Cloudflare/GCS external state
  - rebuild and live-state audit commands

- `APPBLOC_RESTORE.md`
  - exact committed Edge AppBloc inputs
  - resources Terraform creates
  - required local files and Cloudflare/GCS external state
  - rebuild and live-state audit commands

## Notes

No infrastructure code is changed.

The docs do not include any secret contents. They do repeat values already committed in the repo, including Cloudflare tunnel IDs and the existing DropBloc placeholder password, so those are called out as reproducibility/security TODOs.
