### PR TITLE
feat(edge): add accessbloc tailscale gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This is **infra for platform teams** who want control, speed, and massive SaaS c
 * **AppBloc** — *Heroku-core*: public app ingress with ManagedCert, redirects, Cloud Armor hooks
 * **ObsBloc** — *Datadog-core*: Prometheus + Grafana, Autopilot-friendly, minimal alerting bootstrap
 * **SearchBloc** — *Elasticsearch-core*: Meilisearch + static UI behind Nginx, PVC, and daily GCS backups
+* **AccessBloc (edge)** — *Tailscale-core*: private tailnet access, subnet routing, and optional exit-node support for Tiny/homelab nodes
 * Infra helpers: **GKE** and **Cloud Armor** modules
 
 Live running examples:

--- a/blocs/edge/README.md
+++ b/blocs/edge/README.md
@@ -4,6 +4,7 @@ This directory mirrors the GCP blocs but is configured for edge/homelab deployme
 
 Use-case
 - Replace `blocs/gcp/<module>` with `blocs/edge/<module>` in example or environment module sources to target edge/homelab.
+- `accessbloc` deploys a Tailscale access gateway/subnet router for private access to a Tiny or homelab network.
 
 Examples:
 - Relative:

--- a/blocs/edge/accessbloc/README.md
+++ b/blocs/edge/accessbloc/README.md
@@ -1,0 +1,134 @@
+# AccessBloc (Edge) - Tailscale Access Gateway
+
+AccessBloc deploys a Tailscale node into a homelab or Tiny Kubernetes cluster. It is intended to provide private tailnet access to a local network without exposing inbound ports.
+
+It can run as:
+
+- a tailnet node with a stable hostname
+- a subnet router for LAN CIDRs
+- an optional exit node
+- an optional Tailscale SSH target
+
+## What Terraform Manages
+
+- Kubernetes namespace
+- optional Kubernetes Secret for `TS_AUTHKEY`
+- ServiceAccount
+- PVC for Tailscale state
+- Deployment running `tailscale/tailscale:stable`
+- `/dev/net/tun` hostPath mount
+- `NET_ADMIN` and `NET_RAW` container capabilities
+
+## What You Must Provide
+
+- A working Kubernetes cluster on the Tiny.
+- A kubeconfig on the Terraform runner.
+- `/dev/net/tun` available on the Tiny.
+- IP forwarding enabled on the Tiny when advertising subnet routes or exit-node access.
+- A Tailscale auth key stored in a Kubernetes Secret, or passed through `auth_key`.
+- Tailnet admin approval for advertised subnet routes or exit-node use.
+
+For a public repo, prefer creating the auth-key Secret manually. Passing `auth_key` to Terraform is supported, but stores the sensitive value in Terraform state.
+
+## Manual Restore Checklist
+
+1. Install the OS and Kubernetes on the Tiny.
+
+2. Confirm the TUN device exists:
+
+   ```bash
+   test -c /dev/net/tun
+   ```
+
+3. Enable IP forwarding if advertising routes or exit-node access:
+
+   ```bash
+   sudo sysctl -w net.ipv4.ip_forward=1
+   sudo sysctl -w net.ipv6.conf.all.forwarding=1
+   ```
+
+   Persist these settings through your OS network/sysctl configuration if this node must survive reboot.
+
+4. Copy kubeconfig to the Terraform runner and verify access:
+
+   ```bash
+   kubectl --kubeconfig ~/.kube/edge get nodes
+   ```
+
+5. Create a reusable or ephemeral Tailscale auth key in the Tailscale admin console.
+
+6. Create the namespace and Kubernetes Secret outside git:
+
+   ```bash
+   kubectl --kubeconfig ~/.kube/edge create namespace accessbloc
+   kubectl --kubeconfig ~/.kube/edge -n accessbloc create secret generic tailscale-auth \
+     --from-literal=TS_AUTHKEY='tskey-auth-REPLACE_ME'
+   ```
+
+7. Apply Terraform from your AccessBloc root:
+
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+8. Approve subnet routes or exit-node use in the Tailscale admin console if configured.
+
+9. Validate:
+
+   ```bash
+   kubectl --kubeconfig ~/.kube/edge -n accessbloc get pods
+   kubectl --kubeconfig ~/.kube/edge -n accessbloc logs deploy/accessbloc
+   ```
+
+## Example
+
+```hcl
+module "accessbloc" {
+  source = "github.com/cloudbloc/cloudbloc//blocs/edge/accessbloc"
+
+  namespace          = "accessbloc"
+  create_namespace   = false
+  app_name           = "accessbloc"
+  tailscale_hostname = "tiny-accessbloc"
+
+  # Secret must exist before apply:
+  # kubectl -n accessbloc create secret generic tailscale-auth \
+  #   --from-literal=TS_AUTHKEY='tskey-auth-REPLACE_ME'
+  auth_key_secret_name = "tailscale-auth"
+
+  # Example LAN behind the Tiny.
+  advertise_routes = ["10.0.0.0/24"]
+}
+```
+
+## Inputs
+
+| Variable | Description |
+| --- | --- |
+| `namespace` | Kubernetes namespace. |
+| `create_namespace` | Whether Terraform should create the namespace. |
+| `app_name` | Name used for resources. |
+| `image` | Tailscale image. |
+| `auth_key` | Optional auth key. Prefer an existing Secret for public repos. |
+| `auth_key_secret_name` | Secret containing the auth key. |
+| `auth_key_secret_key` | Secret key containing the auth key. |
+| `tailscale_hostname` | Hostname registered in the tailnet. |
+| `advertise_routes` | CIDR routes advertised by this node. |
+| `accept_routes` | Whether to accept routes from the tailnet. |
+| `advertise_exit_node` | Whether to advertise this node as an exit node. |
+| `enable_ssh` | Whether to enable Tailscale SSH. |
+| `extra_args` | Extra `tailscale up` arguments. |
+| `host_network` | Whether to use the host network namespace. |
+| `privileged` | Whether the Tailscale container runs privileged. |
+| `state_storage_size` | PVC size for state. |
+| `state_storage_class_name` | StorageClass for state PVC. |
+
+## Security Notes
+
+- Do not commit Tailscale auth keys.
+- Do not commit kubeconfigs.
+- Use ephemeral auth keys when possible.
+- Approve only the subnet routes that should be reachable from the tailnet.
+- ACLs and device/user permissions are managed in Tailscale, not this module.

--- a/blocs/edge/accessbloc/main.tf
+++ b/blocs/edge/accessbloc/main.tf
@@ -1,0 +1,195 @@
+locals {
+  namespace = var.namespace
+
+  common_labels = merge(
+    {
+      app = var.app_name
+    },
+    var.labels
+  )
+
+  tailscale_args = concat(
+    [
+      "--hostname=${var.tailscale_hostname}",
+    ],
+    length(var.advertise_routes) > 0 ? ["--advertise-routes=${join(",", var.advertise_routes)}"] : [],
+    var.accept_routes ? ["--accept-routes"] : [],
+    var.advertise_exit_node ? ["--advertise-exit-node"] : [],
+    var.enable_ssh ? ["--ssh"] : [],
+    var.extra_args
+  )
+}
+
+resource "kubernetes_namespace_v1" "this" {
+  count = var.create_namespace ? 1 : 0
+
+  metadata {
+    name = local.namespace
+  }
+}
+
+resource "kubernetes_secret_v1" "auth_key" {
+  count = var.auth_key == null ? 0 : 1
+
+  metadata {
+    name      = var.auth_key_secret_name
+    namespace = local.namespace
+    labels    = local.common_labels
+  }
+
+  data = {
+    (var.auth_key_secret_key) = var.auth_key
+  }
+
+  type = "Opaque"
+
+  depends_on = [
+    kubernetes_namespace_v1.this,
+  ]
+}
+
+resource "kubernetes_service_account_v1" "this" {
+  metadata {
+    name      = var.app_name
+    namespace = local.namespace
+    labels    = local.common_labels
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.this,
+  ]
+}
+
+resource "kubernetes_persistent_volume_claim_v1" "state" {
+  metadata {
+    name      = "${var.app_name}-state"
+    namespace = local.namespace
+    labels    = local.common_labels
+  }
+
+  wait_until_bound = false
+
+  spec {
+    access_modes = ["ReadWriteOnce"]
+
+    resources {
+      requests = {
+        storage = var.state_storage_size
+      }
+    }
+
+    storage_class_name = var.state_storage_class_name
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.this,
+  ]
+}
+
+resource "kubernetes_deployment_v1" "this" {
+  metadata {
+    name      = var.app_name
+    namespace = local.namespace
+    labels    = local.common_labels
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = var.app_name
+      }
+    }
+
+    template {
+      metadata {
+        labels = local.common_labels
+      }
+
+      spec {
+        service_account_name = kubernetes_service_account_v1.this.metadata[0].name
+        host_network         = var.host_network
+        dns_policy           = var.host_network ? "ClusterFirstWithHostNet" : "ClusterFirst"
+
+        container {
+          name  = "tailscale"
+          image = var.image
+
+          env {
+            name = "TS_AUTHKEY"
+            value_from {
+              secret_key_ref {
+                name = var.auth_key_secret_name
+                key  = var.auth_key_secret_key
+              }
+            }
+          }
+
+          env {
+            name  = "TS_STATE_DIR"
+            value = "/var/lib/tailscale"
+          }
+
+          env {
+            name  = "TS_USERSPACE"
+            value = "false"
+          }
+
+          env {
+            name  = "TS_EXTRA_ARGS"
+            value = join(" ", local.tailscale_args)
+          }
+
+          security_context {
+            privileged = var.privileged
+            capabilities {
+              add = ["NET_ADMIN", "NET_RAW"]
+            }
+          }
+
+          resources {
+            requests = {
+              cpu    = var.resources.requests_cpu
+              memory = var.resources.requests_memory
+            }
+            limits = {
+              cpu    = var.resources.limits_cpu
+              memory = var.resources.limits_memory
+            }
+          }
+
+          volume_mount {
+            name       = "state"
+            mount_path = "/var/lib/tailscale"
+          }
+
+          volume_mount {
+            name       = "tun"
+            mount_path = "/dev/net/tun"
+          }
+        }
+
+        volume {
+          name = "state"
+          persistent_volume_claim {
+            claim_name = kubernetes_persistent_volume_claim_v1.state.metadata[0].name
+          }
+        }
+
+        volume {
+          name = "tun"
+          host_path {
+            path = "/dev/net/tun"
+            type = "CharDevice"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.this,
+    kubernetes_secret_v1.auth_key,
+  ]
+}

--- a/blocs/edge/accessbloc/outputs.tf
+++ b/blocs/edge/accessbloc/outputs.tf
@@ -1,0 +1,24 @@
+output "namespace" {
+  description = "Namespace where AccessBloc is deployed."
+  value       = var.namespace
+}
+
+output "deployment_name" {
+  description = "AccessBloc Deployment name."
+  value       = kubernetes_deployment_v1.this.metadata[0].name
+}
+
+output "auth_key_secret_name" {
+  description = "Secret name used for the Tailscale auth key."
+  value       = var.auth_key_secret_name
+}
+
+output "tailscale_hostname" {
+  description = "Hostname registered in the tailnet."
+  value       = var.tailscale_hostname
+}
+
+output "advertise_routes" {
+  description = "Routes advertised by AccessBloc."
+  value       = var.advertise_routes
+}

--- a/blocs/edge/accessbloc/variables.tf
+++ b/blocs/edge/accessbloc/variables.tf
@@ -1,0 +1,124 @@
+variable "namespace" {
+  description = "Kubernetes namespace for AccessBloc."
+  type        = string
+  default     = "accessbloc"
+}
+
+variable "create_namespace" {
+  description = "Whether Terraform should create the namespace. Set false when pre-creating the namespace and auth-key Secret outside Terraform."
+  type        = bool
+  default     = true
+}
+
+variable "app_name" {
+  description = "Name used for AccessBloc Kubernetes resources."
+  type        = string
+  default     = "accessbloc"
+}
+
+variable "image" {
+  description = "Tailscale container image."
+  type        = string
+  default     = "tailscale/tailscale:stable"
+}
+
+variable "labels" {
+  description = "Additional labels to attach to AccessBloc resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "auth_key" {
+  description = "Optional Tailscale auth key. Prefer pre-creating a Kubernetes Secret and setting auth_key_secret_name to avoid storing this in Terraform state."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "auth_key_secret_name" {
+  description = "Name of an existing Secret containing the Tailscale auth key. The key must be auth_key_secret_key."
+  type        = string
+  default     = "tailscale-auth"
+}
+
+variable "auth_key_secret_key" {
+  description = "Key inside auth_key_secret_name that contains the Tailscale auth key."
+  type        = string
+  default     = "TS_AUTHKEY"
+}
+
+variable "tailscale_hostname" {
+  description = "Hostname to register in the tailnet."
+  type        = string
+  default     = "accessbloc"
+}
+
+variable "advertise_routes" {
+  description = "CIDR routes to advertise through this node, for example the Tiny LAN CIDR."
+  type        = list(string)
+  default     = []
+}
+
+variable "accept_routes" {
+  description = "Whether this node should accept routes advertised by other tailnet nodes."
+  type        = bool
+  default     = false
+}
+
+variable "advertise_exit_node" {
+  description = "Whether to advertise this node as a tailnet exit node."
+  type        = bool
+  default     = false
+}
+
+variable "enable_ssh" {
+  description = "Whether to enable Tailscale SSH for this node."
+  type        = bool
+  default     = false
+}
+
+variable "extra_args" {
+  description = "Additional tailscale up arguments."
+  type        = list(string)
+  default     = []
+}
+
+variable "host_network" {
+  description = "Run the Tailscale pod in the host network namespace. Recommended for Tiny subnet-router deployments."
+  type        = bool
+  default     = true
+}
+
+variable "privileged" {
+  description = "Run the Tailscale container as privileged. Useful on edge clusters where /dev/net/tun or routing needs elevated access."
+  type        = bool
+  default     = true
+}
+
+variable "state_storage_size" {
+  description = "PVC size for Tailscale state."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "state_storage_class_name" {
+  description = "StorageClass name for the state PVC. Set to null for cluster default."
+  type        = string
+  default     = null
+}
+
+variable "resources" {
+  description = "CPU and memory requests/limits for the Tailscale container."
+  type = object({
+    requests_cpu    = string
+    requests_memory = string
+    limits_cpu      = string
+    limits_memory   = string
+  })
+  default = {
+    requests_cpu    = "50m"
+    requests_memory = "128Mi"
+    limits_cpu      = "250m"
+    limits_memory   = "256Mi"
+  }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,7 @@ Examples live under `examples/`. Each example demonstrates how to call blocs in 
 
 - examples/gcp/* — GCP-targeted examples (use `blocs/gcp/...` sources).
 - examples/edge/* — edge-targeted examples (use `blocs/edge/...` sources).
+- examples/edge/accessbloc — Tailscale access gateway/subnet-router example for a Tiny or homelab node.
 
 Run an example:
 ```bash

--- a/examples/edge/accessbloc/backend.tf
+++ b/examples/edge/accessbloc/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "gcs" {
+    prefix = "edge-accessbloc"
+  }
+}

--- a/examples/edge/accessbloc/backend/prd.conf
+++ b/examples/edge/accessbloc/backend/prd.conf
@@ -1,0 +1,1 @@
+bucket = "cloudbloc-tfstate-prd"

--- a/examples/edge/accessbloc/main.tf
+++ b/examples/edge/accessbloc/main.tf
@@ -1,0 +1,18 @@
+module "accessbloc" {
+  source = "../../../blocs/edge/accessbloc"
+
+  namespace            = var.namespace
+  create_namespace     = var.create_namespace
+  app_name             = "accessbloc"
+  tailscale_hostname   = var.tailscale_hostname
+  auth_key_secret_name = var.auth_key_secret_name
+
+  advertise_routes    = var.advertise_routes
+  advertise_exit_node = var.advertise_exit_node
+  enable_ssh          = var.enable_ssh
+
+  labels = {
+    bloc = "accessbloc"
+    env  = "prd"
+  }
+}

--- a/examples/edge/accessbloc/provider.tf
+++ b/examples/edge/accessbloc/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.29.0"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/edge"
+}

--- a/examples/edge/accessbloc/variables.tf
+++ b/examples/edge/accessbloc/variables.tf
@@ -1,0 +1,41 @@
+variable "namespace" {
+  description = "Kubernetes namespace for AccessBloc."
+  type        = string
+  default     = "accessbloc"
+}
+
+variable "tailscale_hostname" {
+  description = "Hostname to register in the tailnet."
+  type        = string
+  default     = "tiny-accessbloc"
+}
+
+variable "create_namespace" {
+  description = "Whether Terraform should create the namespace. Keep false when the auth-key Secret is pre-created manually."
+  type        = bool
+  default     = false
+}
+
+variable "auth_key_secret_name" {
+  description = "Existing Secret containing TS_AUTHKEY."
+  type        = string
+  default     = "tailscale-auth"
+}
+
+variable "advertise_routes" {
+  description = "CIDR routes to advertise through this Tiny."
+  type        = list(string)
+  default     = ["10.0.0.0/24"]
+}
+
+variable "advertise_exit_node" {
+  description = "Whether to advertise this Tiny as an exit node."
+  type        = bool
+  default     = false
+}
+
+variable "enable_ssh" {
+  description = "Whether to enable Tailscale SSH."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

Adds `AccessBloc`, an edge/Tiny bloc for deploying a Tailscale access gateway into a homelab Kubernetes cluster.

## What It Adds

- `blocs/edge/accessbloc`
  - Tailscale Deployment using `tailscale/tailscale:stable`
  - PVC-backed Tailscale state
  - optional Terraform-created auth-key Secret
  - preferred pre-created Secret flow for public repos
  - host networking by default for Tiny/subnet-router deployments
  - `/dev/net/tun` hostPath mount
  - `NET_ADMIN` / `NET_RAW` capabilities and privileged edge-compatible default
  - subnet route advertising
  - optional exit-node support
  - optional Tailscale SSH
  - route acceptance and extra-args knobs

- `examples/edge/accessbloc`
  - deployable Tiny/homelab example using `~/.kube/edge`
  - no committed auth key
  - expects a manually created `tailscale-auth` Secret with `TS_AUTHKEY`
  - backend prefix `edge-accessbloc`

- README updates
  - root README lists AccessBloc
  - edge README lists AccessBloc
  - examples README lists the new edge example

## Security Notes

No Tailscale auth key or credential material is committed.

The docs use only a placeholder:

```text
tskey-auth-REPLACE_ME
```

The example defaults to a pre-created Kubernetes Secret so auth keys do not need to be stored in Terraform state.

## Validation

```bash
terraform fmt -recursive blocs/edge/accessbloc examples/edge/accessbloc
terraform -chdir=examples/edge/accessbloc init -backend=false
terraform -chdir=examples/edge/accessbloc validate
```

Validation passed.
