### PR TITLE
feat(streambloc): publish edge module source

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -26,6 +26,10 @@
       "release-type": "terraform-module",
       "component": "edge-appbloc"
     },
+    "blocs/edge/streambloc": {
+      "release-type": "terraform-module",
+      "component": "edge-streambloc"
+    },
     "modules/cloudarmor": {
       "release-type": "terraform-module",
       "component": "cloudarmor"

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -6,5 +6,6 @@
     "blocs/edge/dropbloc": "0.3.0",
     "modules/cloudarmor": "0.2.1",
     "modules/gke": "0.2.1",
-    "blocs/edge/appbloc": "0.2.0"
+    "blocs/edge/appbloc": "0.2.0",
+    "blocs/edge/streambloc": "0.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ All can be deployed within minutes on your own cloud using the pre-built blocs.
 * `blocs/gcp/appbloc`: **v0.4.2**
 * `blocs/gcp/obsbloc`: **v0.4.2**
 * `blocs/gcp/searchbloc`: **v0.4.2**
+* `blocs/edge/streambloc`: **pending v0.1.0**
 * `modules/gke`: **v0.2.1**, `modules/cloudarmor`: **v0.2.1**
 
-Release automation: **release-please (manifest mode)** with per-bloc tagging (e.g. `searchbloc-0.4.2`).
+Release automation: **release-please (manifest mode)** with per-bloc tagging (e.g. `gcp-searchbloc-v0.4.2`, `edge-streambloc-v0.1.0`).
 
 ---
 

--- a/blocs/edge/streambloc/README.md
+++ b/blocs/edge/streambloc/README.md
@@ -92,7 +92,8 @@ From an example/root module, pass the Tiny host and storage settings:
 
 ```hcl
 module "streambloc" {
-  source = "../../../blocs/edge/streambloc"
+  source = "github.com/cloudbloc/cloudbloc//blocs/edge/streambloc?ref=edge-streambloc-v0.1.0"
+  # source = "../../../blocs/edge/streambloc"
 
   tiny_host = "10.0.0.187"
   tiny_user = "yprk"

--- a/examples/edge/streambloc/README.md
+++ b/examples/edge/streambloc/README.md
@@ -4,6 +4,18 @@ This example deploys StreamBloc to a Tiny over SSH, using Terraform to run an id
 
 It is private-network only. Use Tailscale for secure remote access.
 
+The example calls StreamBloc by tag:
+
+```hcl
+source = "github.com/cloudbloc/cloudbloc//blocs/edge/streambloc?ref=edge-streambloc-v0.1.0"
+```
+
+For local development, switch the source to:
+
+```hcl
+source = "../../../blocs/edge/streambloc"
+```
+
 ## What Terraform Does
 
 - connects to the Tiny with SSH

--- a/examples/edge/streambloc/main.tf
+++ b/examples/edge/streambloc/main.tf
@@ -1,5 +1,6 @@
 module "streambloc" {
-  source = "../../../blocs/edge/streambloc"
+  source = "github.com/cloudbloc/cloudbloc//blocs/edge/streambloc?ref=edge-streambloc-v0.1.0"
+  # source = "../../../blocs/edge/streambloc"
 
   tiny_host            = var.tiny_host
   tiny_user            = var.tiny_user


### PR DESCRIPTION
## Summary
- switch the StreamBloc example to the tagged GitHub module source
- keep the local module source commented for development rollback
- register edge StreamBloc with release-please so it can publish edge-streambloc-v0.1.0

## Verification
- terraform fmt -check examples/edge/streambloc blocs/edge/streambloc
- jq . .github/release-please-config.json
- jq . .github/release-please-manifest.json

## Rollback
- local source remains commented in examples/edge/streambloc/main.tf
- backup branch backup/streambloc-local-source points to the pre-change state