### PR TITLE
feat(guardbloc): publish edge module source

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -30,6 +30,10 @@
       "release-type": "terraform-module",
       "component": "edge-streambloc"
     },
+    "blocs/edge/guardbloc": {
+      "release-type": "terraform-module",
+      "component": "edge-guardbloc"
+    },
     "modules/cloudarmor": {
       "release-type": "terraform-module",
       "component": "cloudarmor"

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -7,5 +7,6 @@
     "modules/cloudarmor": "0.2.1",
     "modules/gke": "0.2.1",
     "blocs/edge/appbloc": "0.2.0",
-    "blocs/edge/streambloc": "0.1.0"
+    "blocs/edge/streambloc": "0.1.0",
+    "blocs/edge/guardbloc": "0.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ This is **infra for platform teams** who want control, speed, and massive SaaS c
 * **ObsBloc** — *Datadog-core*: Prometheus + Grafana, Autopilot-friendly, minimal alerting bootstrap
 * **SearchBloc** — *Elasticsearch-core*: Meilisearch + static UI behind Nginx, PVC, and daily GCS backups
 * **StreamBloc (edge)** — *Jellyfin-core*: Docker Compose media server for Tiny/homelab streaming
+* **GuardBloc (edge)** — *AdGuard Home-core*: private DNS filtering and local rewrites for LAN/tailnet clients
 * Infra helpers: **GKE** and **Cloud Armor** modules
 
 Live running examples:
@@ -104,9 +105,10 @@ All can be deployed within minutes on your own cloud using the pre-built blocs.
 * `blocs/gcp/obsbloc`: **v0.4.2**
 * `blocs/gcp/searchbloc`: **v0.4.2**
 * `blocs/edge/streambloc`: **pending v0.1.0**
+* `blocs/edge/guardbloc`: **pending v0.1.0**
 * `modules/gke`: **v0.2.1**, `modules/cloudarmor`: **v0.2.1**
 
-Release automation: **release-please (manifest mode)** with per-bloc tagging (e.g. `gcp-searchbloc-v0.4.2`, `edge-streambloc-v0.1.0`).
+Release automation: **release-please (manifest mode)** with per-bloc tagging (e.g. `gcp-searchbloc-v0.4.2`, `edge-guardbloc-v0.1.0`).
 
 ---
 

--- a/blocs/edge/README.md
+++ b/blocs/edge/README.md
@@ -5,6 +5,7 @@ This directory mirrors the GCP blocs but is configured for edge/homelab deployme
 Use-case
 - Replace `blocs/gcp/<module>` with `blocs/edge/<module>` in example or environment module sources to target edge/homelab.
 - `streambloc` provides a Docker Compose based Jellyfin media server for Tiny/homelab streaming.
+- `guardbloc` provides a Docker Compose based AdGuard Home DNS/filtering service for private LAN or tailnet use.
 
 Examples:
 - Relative:

--- a/blocs/edge/guardbloc/README.md
+++ b/blocs/edge/guardbloc/README.md
@@ -70,6 +70,13 @@ terraform apply \
   -var='service_bind_ip=192.168.1.50'
 ```
 
+Module source for released usage:
+
+```hcl
+source = "github.com/cloudbloc/cloudbloc//blocs/edge/guardbloc?ref=edge-guardbloc-v0.1.0"
+# source = "../../../blocs/edge/guardbloc"
+```
+
 Open AdGuard setup/admin UI:
 
 ```text

--- a/examples/edge/guardbloc/README.md
+++ b/examples/edge/guardbloc/README.md
@@ -4,6 +4,18 @@ This example deploys GuardBloc to an edge host over SSH, using Terraform to run 
 
 It is private-network only. Use LAN/Tailscale for access.
 
+The example calls GuardBloc by tag:
+
+```hcl
+source = "github.com/cloudbloc/cloudbloc//blocs/edge/guardbloc?ref=edge-guardbloc-v0.1.0"
+```
+
+For local development, switch the source to:
+
+```hcl
+source = "../../../blocs/edge/guardbloc"
+```
+
 ## What Terraform Does
 
 - connects to the edge host with SSH

--- a/examples/edge/guardbloc/main.tf
+++ b/examples/edge/guardbloc/main.tf
@@ -1,5 +1,6 @@
 module "guardbloc" {
-  source = "../../../blocs/edge/guardbloc"
+  source = "github.com/cloudbloc/cloudbloc//blocs/edge/guardbloc?ref=edge-guardbloc-v0.1.0"
+  # source = "../../../blocs/edge/guardbloc"
 
   host                 = var.host
   ssh_user             = var.ssh_user


### PR DESCRIPTION
Register GuardBloc with release-please manifest mode as edge-guardbloc so the release workflow can cut the initial edge-guardbloc-v0.1.0 tag.

Switch the GuardBloc edge example to the pinned GitHub module source and keep the local source as the development fallback.

Document the released module source in the example, GuardBloc module README, edge bloc index, and root module/version overview.

## What
- Short summary

## Why
- Motivation / context

## How
- Key implementation notes
- User-visible changes (docs, inputs/outputs)

## Testing
- [ ] Applied against test cluster
- [ ] Smoke test passed
