### PR TITLE
feat(homebloc): enable release please

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -41,6 +41,10 @@
     "modules/gke": {
       "release-type": "terraform-module",
       "component": "gke"
+    },
+    "blocs/edge/homebloc": {
+      "release-type": "terraform-module",
+      "component": "edge-homebloc"
     }
   }
 }

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -8,5 +8,6 @@
     "modules/gke": "0.2.1",
     "blocs/edge/appbloc": "0.2.0",
     "blocs/edge/streambloc": "0.1.0",
-    "blocs/edge/guardbloc": "0.2.0"
+    "blocs/edge/guardbloc": "0.2.0",
+    "blocs/edge/homebloc": "0.0.0"
 }


### PR DESCRIPTION
## Summary
- register blocs/edge/homebloc with Release Please as edge-homebloc
- seed the Release Please manifest at 0.0.0 so the first release can become edge-homebloc-v0.1.0

## Verification
- parsed release-please-config.json and release-please-manifest.json as valid JSON
- git diff --check