### PR TITLE
docs(edge): update released module references

### DIFF
--- a/blocs/edge/appbloc/README.md
+++ b/blocs/edge/appbloc/README.md
@@ -92,7 +92,7 @@ locals {
 }
 
 module "appbloc" {
-  source = "github.com/cloudbloc/cloudbloc//blocs/edge/appbloc"
+  source = "github.com/cloudbloc/cloudbloc//blocs/edge/appbloc?ref=edge-appbloc-v0.3.0"
 
   namespace      = var.app_namespace
   app_name       = "cloudbloc-webapp-${var.environment}"
@@ -125,7 +125,7 @@ Set `create_namespace = false` when another Terraform state already manages the 
 
 ```hcl
 module "appbloc" {
-  source = "github.com/cloudbloc/cloudbloc//blocs/edge/appbloc"
+  source = "github.com/cloudbloc/cloudbloc//blocs/edge/appbloc?ref=edge-appbloc-v0.3.0"
 
   namespace        = "automation"
   create_namespace = false

--- a/examples/edge/appbloc/main.tf
+++ b/examples/edge/appbloc/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "appbloc" {
-  # source = "github.com/cloudbloc/cloudbloc//blocs/edge/appbloc?ref=edge-appbloc-v0.1.0"
+  # source = "github.com/cloudbloc/cloudbloc//blocs/edge/appbloc?ref=edge-appbloc-v0.3.0"
   source = "../../../blocs/edge/appbloc"
 
   namespace      = var.app_namespace

--- a/examples/edge/homebloc/README.md
+++ b/examples/edge/homebloc/README.md
@@ -10,7 +10,7 @@ For local development, the example calls HomeBloc by relative source:
 source = "../../../blocs/edge/homebloc"
 ```
 
-After HomeBloc is released, switch to a pinned GitHub source:
+Use a pinned GitHub source for released HomeBloc modules:
 
 ```hcl
 source = "github.com/cloudbloc/cloudbloc//blocs/edge/homebloc?ref=edge-homebloc-v0.1.0"


### PR DESCRIPTION
## Summary
- update edge appbloc documented sources to edge-appbloc-v0.3.0
- update the edge appbloc example commented release source to edge-appbloc-v0.3.0
- clarify that edge homebloc now has a released pinned source at edge-homebloc-v0.1.0

## Verification
- fetched latest main and tags
- confirmed tags edge-appbloc-v0.3.0 and edge-homebloc-v0.1.0 exist
- scanned for unpinned GitHub edge appbloc/homebloc sources
- git diff --check