### PR TITLE
[codex] fix HomeBloc automation include

### DIFF
--- a/blocs/edge/homebloc/README.md
+++ b/blocs/edge/homebloc/README.md
@@ -24,7 +24,8 @@ It is intended for private LAN/Tailscale use:
 - optionally installs Docker on Ubuntu/Debian if missing
 - creates persistent folders under `homebloc_root`
 - writes `/opt/homebloc/.env`
-- bootstraps `configuration.yaml` only if it does not exist
+- bootstraps `configuration.yaml` and `automations.yaml` if they do not exist
+- ensures `configuration.yaml` includes `automations.yaml` for the UI automation editor
 - runs `docker compose pull`
 - runs `docker compose up -d`
 
@@ -38,6 +39,7 @@ Terraform never deletes Home Assistant config data.
 /var/lib/homebloc/
   config/
     configuration.yaml
+    automations.yaml
 ```
 
 ## Networking
@@ -50,7 +52,7 @@ The default UI endpoint is:
 http://<host>:8123
 ```
 
-If you change `http_port`, HomeBloc only sets the bootstrap `configuration.yaml` when the file does not already exist. Existing Home Assistant config remains user-owned.
+If you change `http_port`, HomeBloc only sets the bootstrap HTTP port when `configuration.yaml` does not already exist. Existing Home Assistant config remains user-owned, but HomeBloc will add the standard `automation: !include automations.yaml` line when it is missing so UI-created automations are loaded.
 
 ## Deploy
 

--- a/blocs/edge/homebloc/scripts/deploy-homebloc.sh
+++ b/blocs/edge/homebloc/scripts/deploy-homebloc.sh
@@ -57,6 +57,19 @@ default_config:
 
 http:
   server_port: $HTTP_PORT
+
+automation: !include automations.yaml
+EOF
+  fi
+
+  if [ ! -f "$HOMEBLOC_ROOT/config/automations.yaml" ]; then
+    printf '[]\n' >"$HOMEBLOC_ROOT/config/automations.yaml"
+  fi
+
+  if ! grep -Eq '^[[:space:]]*automation:' "$HOMEBLOC_ROOT/config/configuration.yaml"; then
+    cat >>"$HOMEBLOC_ROOT/config/configuration.yaml" <<EOF
+
+automation: !include automations.yaml
 EOF
   fi
 }

--- a/examples/edge/homebloc/README.md
+++ b/examples/edge/homebloc/README.md
@@ -24,7 +24,8 @@ source = "github.com/cloudbloc/cloudbloc//blocs/edge/homebloc?ref=edge-homebloc-
 - optionally installs Docker on Ubuntu/Debian if missing
 - creates persistent folders under `homebloc_root`
 - writes `/opt/homebloc/.env`
-- bootstraps `configuration.yaml` only if it does not exist
+- bootstraps `configuration.yaml` and `automations.yaml` if they do not exist
+- ensures `configuration.yaml` includes `automations.yaml` for the UI automation editor
 - runs `docker compose pull`
 - runs `docker compose up -d`
 


### PR DESCRIPTION
## Summary

Fix HomeBloc's Home Assistant bootstrap so UI-created automations are actually loaded.

## Root Cause

HomeBloc created `/var/lib/homebloc/config/configuration.yaml` without the standard:

```yaml
automation: !include automations.yaml
```

That allowed the Home Assistant UI to save automation YAML into `automations.yaml`, but the running automation integration did not load that file after deploy/recreate.

## Changes

- Add `automation: !include automations.yaml` to newly bootstrapped `configuration.yaml`.
- Create `automations.yaml` as `[]` when it does not exist.
- For existing HomeBloc installs, append the automation include only when no active `automation:` key exists.
- Update HomeBloc module and example docs to describe the automation bootstrap behavior.

## Validation

- `sh -n blocs/edge/homebloc/scripts/deploy-homebloc.sh`
- Temp bootstrap test confirmed new installs create `configuration.yaml` with `automation: !include automations.yaml` and `automations.yaml` containing `[]`.
- Temp upgrade test confirmed existing configs without `automation:` get the include appended.
- Temp custom-config test confirmed existing configs with an `automation:` key are not given a duplicate key.
